### PR TITLE
[REFACTOR] : BaseResponse 수정 및 AOP 추가

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,11 +3,10 @@ name: Build Test
 on:
   pull_request:
     paths:
-      - 'backend/src/**'
-      - 'backend/build.gradle'
-      - 'backend/build.gradle.kts'
-#    branches:
-#      - dev
+      - 'src/**'
+      - 'build.gradle'
+    branches:
+      - dev
 
 jobs:
   build:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,4 +1,4 @@
-name: Build Test
+name: Build with GraalVM
 
 on:
   pull_request:
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.3.4
 
-      - name: Set up JDK
-        uses: actions/setup-java@v2
+      - name: GitHub Action for GraalVM
+        uses: graalvm/setup-graalvm@v1.3.3
         with:
-          java-version: '21'
-          distribution: 'graalvm'
+          java-version: '21'  # 사용할 GraalVM 버전
+          distribution: 'graalvm'  # GraalVM 배포판
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/src/main/java/ssammudan/cotree/global/response/BaseResponse.java
+++ b/src/main/java/ssammudan/cotree/global/response/BaseResponse.java
@@ -1,7 +1,9 @@
 package ssammudan.cotree.global.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,51 +11,56 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@JsonInclude(Include.NON_NULL)
 @Builder(access = AccessLevel.PRIVATE)
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class BaseResponse<T> {
 
-    @NotNull
-    private final Boolean isSuccess;
-    @NotNull
-    private final String  code;
-    @NotNull
-    private final String  message;
-    private final T       data;
+	@JsonIgnore
+	private final HttpStatus httpStatus;
+	@NotNull
+	private final Boolean isSuccess;
+	@NotNull
+	private final String code;
+	@NotNull
+	private final String message;
+	private final T data;
 
-    public static <T> BaseResponse<T> success(final SuccessCode successCode, final T data) {
-        return BaseResponse.<T>builder()
-                           .isSuccess(true)
-                           .code(successCode.getCode())
-                           .message(successCode.getMessage())
-                           .data(data)
-                           .build();
-    }
+	public static <T> BaseResponse<T> success(final SuccessCode successCode, final T data) {
+		return BaseResponse.<T>builder()
+				.httpStatus(successCode.getStatus())
+				.isSuccess(true)
+				.code(successCode.getCode())
+				.message(successCode.getMessage())
+				.data(data)
+				.build();
+	}
 
-    public static <T> BaseResponse<T> success(final SuccessCode successCode) {
-        return BaseResponse.<T>builder()
-                           .isSuccess(true)
-                           .code(successCode.getCode())
-                           .message(successCode.getMessage())
-                           .data(null)
-                           .build();
-    }
+	public static <T> BaseResponse<T> success(final SuccessCode successCode) {
+		return BaseResponse.<T>builder()
+				.httpStatus(successCode.getStatus())
+				.isSuccess(true)
+				.code(successCode.getCode())
+				.message(successCode.getMessage())
+				.data(null)
+				.build();
+	}
 
-    public static <T> BaseResponse<T> fail(final ErrorCode errorCode) {
-        return BaseResponse.<T>builder()
-                           .isSuccess(true)
-                           .code(errorCode.getCode())
-                           .message(errorCode.getMessage())
-                           .build();
-    }
+	public static <T> BaseResponse<T> fail(final ErrorCode errorCode) {
+		return BaseResponse.<T>builder()
+				.httpStatus(errorCode.getStatus())
+				.isSuccess(false)
+				.code(errorCode.getCode())
+				.message(errorCode.getMessage())
+				.build();
+	}
 
-    public static <T> BaseResponse<T> fail(final ErrorCode errorCode, final String message) {
-        return BaseResponse.<T>builder()
-                           .isSuccess(true)
-                           .code(errorCode.getCode())
-                           .message(message)
-                           .build();
-    }
+	public static <T> BaseResponse<T> fail(final ErrorCode errorCode, final String message) {
+		return BaseResponse.<T>builder()
+				.httpStatus(errorCode.getStatus())
+				.isSuccess(false)
+				.code(errorCode.getCode())
+				.message(message)
+				.build();
+	}
 
 }

--- a/src/main/java/ssammudan/cotree/global/response/aop/HttpResponseStatusAspect.java
+++ b/src/main/java/ssammudan/cotree/global/response/aop/HttpResponseStatusAspect.java
@@ -1,0 +1,63 @@
+package ssammudan.cotree.global.response.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.global.response.BaseResponse;
+
+/**
+ * PackageName : ssammudan.cotree.global.response.aop
+ * FileName    : HttpResponseStatusAspect
+ * Author      : Baekgwa
+ * Date        : 2025-03-28
+ * Description : HttpResponse httpStatus <-> BaseResponse.HttpStatus 동기화
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-03-28     Baekgwa               Initial creation
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class HttpResponseStatusAspect {
+
+	private final HttpServletResponse response;
+
+	@Around("""
+            (
+                within
+                (
+                    @org.springframework.web.bind.annotation.RestController *
+                )
+                &&
+                (
+                    @annotation(org.springframework.web.bind.annotation.GetMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PostMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PutMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.PatchMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.DeleteMapping)
+                    ||
+                    @annotation(org.springframework.web.bind.annotation.RequestMapping)
+                )
+            )
+            ||
+            @annotation(org.springframework.web.bind.annotation.ResponseBody)
+            """)
+	public Object handleResponse(ProceedingJoinPoint joinPoint) throws Throwable {
+		Object proceed = joinPoint.proceed();
+
+		if (proceed instanceof BaseResponse<?> baseResponse) {
+			response.setStatus(baseResponse.getHttpStatus().value());
+		}
+
+		return proceed;
+	}
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#6 
  <br/>

## 🔎 작업 내용
- BaseResponse, data 항목 null 이라도 반환하도록 변경
- Controller Layer 응답 시, BaseResponse 의 Httpstatus 에 따라 status 변경되도록 AOP 적용

- 테스트 케이스1) HttpStatus : Create
![image](https://github.com/user-attachments/assets/e095408c-7efe-4ffd-817f-ba191ad28a3a)
- 테스트 케이스2) data 추가
![image](https://github.com/user-attachments/assets/bfbcf520-f853-4a65-ac37-d113f172c60a)
- 테스트 케이스3) Exception 발생 후, `GlobalExceptionHandler` 에서 컨트롤 되는 것 확인
![image](https://github.com/user-attachments/assets/f409f0b1-8dbc-4d07-bc84-ef5623ab787d)

- 테스트 코드
```java
@RestController
@RequestMapping("/api/v1/member")
@RequiredArgsConstructor
public class MemberController {

	@GetMapping("/1")
	public BaseResponse<Void> test1() {
		return BaseResponse.success(SuccessCode.TEST1);
	}

	@GetMapping("/2")
	public BaseResponse<Dto> test2() {
		Dto testDto = new Dto(1, "테스트");
		return BaseResponse.success(SuccessCode.TEST2, testDto);
	}

	@GetMapping("/3")
	public BaseResponse<Void> failTest1() {
		throw new GlobalException(ErrorCode.NOT_FOUND_URL);
	}
}

@Getter
@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
public enum SuccessCode {

	//Member
	TEST1(HttpStatus.CREATED, "201", "api1 응답 성공"),
       TEST2(HttpStatus.OK, "200", "api2 응답 성공"),
```

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>