### PR TITLE
feat: #ET-3 TechBook 페이징 목록 조회 기능 구현

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
@@ -1,8 +1,13 @@
 package ssammudan.cotree.domain.education.techbook.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +29,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.     loadingKKamo21       GET: /api/v1/education/techbook 추가
  */
 @RestController
 @RequestMapping("/api/v1/education/techbook")
@@ -33,13 +39,21 @@ public class TechBookController {
 
 	private final TechBookService techBookService;
 
-	@Operation(summary = "TechBook 조회")
+	@Operation(summary = "TechBook 상세 조회")
 	@GetMapping("/{id}/info")
-	public BaseResponse<TechBookResponse.Detail> getTechBookById(
-		@PathVariable @Min(1) Long id
-	) {
+	public BaseResponse<TechBookResponse.Detail> getTechBookById(@PathVariable @Min(1) Long id) {
 		TechBookResponse.Detail responseDto = techBookService.findTechBookById(id);
 		return BaseResponse.success(SuccessCode.TECH_BOOK_READ_SUCCESS, responseDto);
+	}
+
+	@Operation(summary = "TechBook 목록 조회")
+	@GetMapping
+	public BaseResponse<Page<TechBookResponse.ListInfo>> getTechBooks(
+		@RequestParam(required = false) String keyword,
+		@PageableDefault(page = 0, size = 16, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		Page<TechBookResponse.ListInfo> responseDto = techBookService.findAllTechBooks(keyword, pageable);
+		return BaseResponse.success(SuccessCode.TECH_BOOK_LIST_FIND_SUCCESS, responseDto);
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookRequest.java
@@ -20,15 +20,15 @@ public class TechBookRequest {
 
 	public record Create(
 		//TODO: EducationLevel 파라미터 PK(Long) vs 난이도 명칭(String)
-		@NotBlank(message = "{NotBlank}") String educationLevel,
-		@NotBlank(message = "{NotBlank}") @Size(max = 20) String title,
-		@NotBlank(message = "{NotBlank}") @Size(max = 50) String description,
-		@NotBlank(message = "{NotBlank}") @Size(max = 500) String introduction,
-		@NotBlank(message = "{NotBlank}") String techBookUrl,
-		@NotBlank(message = "{NotBlank}") String techBookPreviewUrl,
-		@NotBlank(message = "{NotBlank}") String techBookThumbnailUrl,
-		@NotNull(message = "{NotNull}") @Min(1) Integer techBookPage,
-		@NotNull(message = "{NotNull}") @Min(1) Integer price
+		@NotBlank String educationLevel,
+		@NotBlank @Size(max = 20) String title,
+		@NotBlank @Size(max = 50) String description,
+		@NotBlank @Size(max = 500) String introduction,
+		@NotBlank String techBookUrl,
+		@NotBlank String techBookPreviewUrl,
+		@NotBlank String techBookThumbnailUrl,
+		@NotNull @Min(1) Integer techBookPage,
+		@NotNull @Min(1) Integer price
 	) {
 	}
 

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
@@ -14,6 +14,7 @@ import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.	 loadingKKamo21       ListInfo 추가
  */
 public class TechBookResponse {
 
@@ -51,6 +52,25 @@ public class TechBookResponse {
 				techBook.getTechBookPage(),
 				techBook.getPrice(),
 				techBook.getViewCount(),
+				techBook.getCreatedAt().toLocalDate()
+			);
+		}
+	}
+
+	public record ListInfo(
+		//TODO: 좋아요 숫자 포함
+		long id,
+		String writer,
+		int price,
+		String techBookThumbnailUrl,
+		LocalDate createdAt
+	) {
+		public static ListInfo from(final TechBook techBook) {
+			return new ListInfo(
+				techBook.getId(),
+				techBook.getWriter().getNickname(),
+				techBook.getPrice(),
+				techBook.getTechBookThumbnailUrl(),
 				techBook.getCreatedAt().toLocalDate()
 			);
 		}

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookService.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookService.java
@@ -1,5 +1,8 @@
 package ssammudan.cotree.domain.education.techbook.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import ssammudan.cotree.domain.education.techbook.dto.TechBookRequest;
 import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
 
@@ -13,11 +16,14 @@ import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.     loadingKKamo21       findAllTechBooks() 추가
  */
 public interface TechBookService {
 
 	Long createTechBook(TechBookRequest.Create requestDto);
 
 	TechBookResponse.Detail findTechBookById(Long id);
+
+	Page<TechBookResponse.ListInfo> findAllTechBooks(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceImpl.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.domain.education.techbook.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ import ssammudan.cotree.model.member.member.type.MemberStatus;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.     loadingKKamo21       findAllTechBooks() 구현
  */
 @Service
 @Transactional(readOnly = true)
@@ -83,6 +86,18 @@ public class TechBookServiceImpl implements TechBookService {
 		TechBook techBook = techBookRepository.findById(id)
 			.orElseThrow(() -> new GlobalException(ErrorCode.TECH_BOOK_NOT_FOUND));
 		return TechBookResponse.Detail.from(techBook);
+	}
+
+	/**
+	 * TechBook 다 건 조회
+	 *
+	 * @param keyword  - 검색어
+	 * @param pageable - 페이징 객체
+	 * @return Page TechBookResponse ListInfo DTO
+	 */
+	@Override
+	public Page<TechBookResponse.ListInfo> findAllTechBooks(final String keyword, final Pageable pageable) {
+		return techBookRepository.findAllTechBooksByKeyword(keyword, pageable).map(TechBookResponse.ListInfo::from);
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode {
 
 	//Education
 	TECH_BOOK_READ_SUCCESS(HttpStatus.OK, "200", "TechBook 조회를 완료했습니다."),
+	TECH_BOOK_LIST_FIND_SUCCESS(HttpStatus.OK, "200", "TechBook 목록 조회를 완료했습니다."),
 
 	//Payment
 

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryCustom.java
@@ -1,5 +1,10 @@
 package ssammudan.cotree.model.education.techbook.techbook.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
+
 /**
  * PackageName : ssammudan.cotree.model.education.techbook.techbook.repository
  * FileName    : TechBookRepositoryCustom
@@ -10,6 +15,10 @@ package ssammudan.cotree.model.education.techbook.techbook.repository;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.	 loadingKKamo21		  findAllTechBooksByKeyword() 추가
  */
 public interface TechBookRepositoryCustom {
+
+	Page<TechBook> findAllTechBooksByKeyword(String keyword, Pageable pageable);
+
 }

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
@@ -1,10 +1,25 @@
 package ssammudan.cotree.model.education.techbook.techbook.repository;
 
-import org.springframework.stereotype.Repository;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.model.education.techbook.techbook.entity.QTechBook;
+import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 
 /**
  * PackageName : ssammudan.cotree.model.education.techbook.techbook.repository
@@ -16,11 +31,90 @@ import lombok.RequiredArgsConstructor;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 28.    loadingKKamo21       Initial creation
+ * 25. 4. 1.	 loadingKKamo21		  findAllTechBooksByKeyword() 구현, getSearchCondition(), getSortCondition() 추가
  */
 @Repository
 @RequiredArgsConstructor
 public class TechBookRepositoryImpl implements TechBookRepositoryCustom {
 
 	private final JPAQueryFactory jpaQueryFactory;
+
+	/**
+	 * 검색어(keyword)로 TechBook 페이징 목록 조회
+	 *
+	 * @param keyword  - 검색어
+	 * @param pageable - 페이징 객체
+	 * @return Page<TechBook>
+	 */
+	@Override
+	public Page<TechBook> findAllTechBooksByKeyword(final String keyword, final Pageable pageable) {
+		QTechBook techBook = QTechBook.techBook;
+		List<TechBook> content = jpaQueryFactory.selectFrom(techBook)
+			.where(getSearchCondition(keyword, techBook))
+			.orderBy(getSortCondition(pageable, techBook))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+		JPAQuery<Long> count = jpaQueryFactory.select(techBook.count())
+			.from(techBook)
+			.where(getSearchCondition(keyword, techBook));
+		return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+	}
+
+	/**
+	 * 검색어(keyword) 기준 BooleanExpression 생성
+	 *
+	 * @param keyword  - 검색어
+	 * @param techBook - Querydsl TechBook
+	 * @return BooleanExpression
+	 */
+	private BooleanExpression getSearchCondition(final String keyword, @NotNull final QTechBook techBook) {
+		BooleanExpression expression = null;
+
+		if (StringUtils.hasText(keyword)) {
+			expression = techBook.title.contains(keyword)
+				.or(techBook.description.contains(keyword))
+				.or(techBook.introduction.contains(keyword));
+		}
+
+		return expression;
+	}
+
+	/**
+	 * 페이징 객체에 포함된 정렬 조건에 따라 OrderSpecifier[] 생성
+	 *
+	 * @param pageable - 페이징 객체
+	 * @param techBook - Querydsl TechBook
+	 * @return OrderSpecifier[]
+	 */
+	private OrderSpecifier<?>[] getSortCondition(@NotNull final Pageable pageable, @NotNull final QTechBook techBook) {
+		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+		if (!pageable.getSort().isEmpty()) {
+			pageable.getSort().forEach(order -> {
+				Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+				switch (order.getProperty()) {
+					case "title" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.title));
+					case "rating" -> orderSpecifiers.add(new OrderSpecifier(direction,
+						Expressions.numberTemplate(Double.class, "CASE WHEN {1} = 0 THEN 0 ELSE ({0} * 1.0 / {1}) END",
+							techBook.totalRating, techBook.totalReviewCount))
+					);
+					case "viewCount" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.viewCount));
+					case "totalReviewCount" ->
+						orderSpecifiers.add(new OrderSpecifier(direction, techBook.totalReviewCount));
+					case "createdAt" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.createdAt));
+					default -> {
+					}
+				}
+			});
+		}
+
+		if (orderSpecifiers.isEmpty()) {
+			orderSpecifiers.add(new OrderSpecifier(Order.DESC, techBook.createdAt));
+		}
+
+		return orderSpecifiers.toArray(new OrderSpecifier[0]);
+	}
 
 }

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -2,14 +2,21 @@ package ssammudan.cotree.domain.education.techbook.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Comparator;
+import java.util.List;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import net.jqwik.api.Arbitraries;
 
@@ -40,6 +47,7 @@ import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPl
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 31.    loadingKKamo21       Initial creation
+ * 25. 4. 1.     loadingKKamo21       findAllTechBooks() 테스트 추가
  */
 @Transactional
 class TechBookServiceTest extends SpringBootTestSupporter {
@@ -53,6 +61,17 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 		.plugin(new JakartaValidationPlugin())
 		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
 		.build();
+
+	@BeforeEach
+	void setup() {
+		em.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();    //H2 DB 외래키 제약 해제
+
+		em.createNativeQuery("TRUNCATE TABLE member RESTART IDENTITY").executeUpdate();
+		em.createNativeQuery("TRUNCATE TABLE education_level RESTART IDENTITY").executeUpdate();
+		em.createNativeQuery("TRUNCATE TABLE tech_book RESTART IDENTITY").executeUpdate();
+
+		em.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();    //H2 DB 외래키 제약 설정
+	}
 
 	@AfterEach
 	void clearEntityContext() {
@@ -80,6 +99,16 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 			.set("techBookPage", Arbitraries.integers().greaterOrEqual(0))
 			.set("price", Arbitraries.integers().greaterOrEqual(0))
 			.sample();
+	}
+
+	private List<TechBook> createTechBooks(final Member member, final EducationLevel educationLevel, final int size) {
+		return entityFixtureMonkey.giveMeBuilder(TechBook.class)
+			.instantiate(Instantiator.factoryMethod("create"))
+			.set("writer", member)
+			.set("educationLevel", educationLevel)
+			.set("techBookPage", Arbitraries.integers().greaterOrEqual(0))
+			.set("price", Arbitraries.integers().greaterOrEqual(0))
+			.sampleList(size);
 	}
 
 	@RepeatedTest(10)
@@ -184,6 +213,52 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 			() -> assertNotNull(globalException, "예외 존재"),
 			() -> assertEquals(globalException.getErrorCode(), ErrorCode.TECH_BOOK_NOT_FOUND, "에러 코드 일치")
 		);
+	}
+
+	@RepeatedTest(10)
+	@DisplayName("[Success] findAllTechBooks(): TechBook 다 건 조회, 페이징 적용")
+	void findAllTechBooks() {
+		//Given
+		Member member = createMember();
+		em.persist(member);
+		EducationLevel educationLevel = createEducationLevel();
+		em.persist(educationLevel);
+		List<TechBook> techBooks = createTechBooks(member, educationLevel, 50);
+		techBooks.forEach(techBook -> em.persist(techBook));
+		clearEntityContext();
+
+		String keyword = dtoFixtureMonkey.giveMeOne(String.class);
+		PageRequest pageable = PageRequest.of(0, 16, Sort.Direction.DESC, "createdAt");
+
+		//When
+		List<TechBookResponse.ListInfo> findAllTechBookResponseDto = techBookService.findAllTechBooks(
+			keyword, pageable
+		).getContent();
+
+		//Then
+		List<TechBookResponse.ListInfo> filteredTechBookResponseDto = techBooks.stream()
+			.filter(techBook ->
+				!StringUtils.hasText(keyword) || (techBook.getTitle().contains(keyword)
+					|| techBook.getDescription().contains(keyword)
+					|| techBook.getIntroduction().contains(keyword))
+			)
+			.sorted(Comparator.comparing(TechBook::getCreatedAt).reversed())
+			.limit(pageable.getPageSize())
+			.map(TechBookResponse.ListInfo::from)
+			.toList();
+
+		assertEquals(filteredTechBookResponseDto.size(), findAllTechBookResponseDto.size(), "검색 결과 갯수 일치");
+		for (int i = 0; i < filteredTechBookResponseDto.size(); i++) {
+			TechBookResponse.ListInfo filteredTechBookDto = filteredTechBookResponseDto.get(i);
+			TechBookResponse.ListInfo findTechBookDto = findAllTechBookResponseDto.get(i);
+
+			assertEquals(filteredTechBookDto.id(), findTechBookDto.id(), "PK 일치");
+			assertEquals(filteredTechBookDto.writer(), findTechBookDto.writer(), "저자 일치");
+			assertEquals(filteredTechBookDto.price(), findTechBookDto.price(), "가격 일치");
+			assertEquals(filteredTechBookDto.techBookThumbnailUrl(), findTechBookDto.techBookThumbnailUrl(),
+				"썸네일 URL 일치");
+			assertEquals(filteredTechBookDto.createdAt(), findTechBookDto.createdAt(), "등록 일자 일치");
+		}
 	}
 
 }

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -116,6 +116,8 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 	void createTechBook() {
 		//TODO: 저자 추가 로직 및 검증
 		//Given
+		setup();
+
 		EducationLevel educationLevel = createEducationLevel();
 		em.persist(educationLevel);
 
@@ -165,6 +167,8 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 	@DisplayName("[Success] findTechBookById(): TechBook 단 건 조회")
 	void findTechBookById() {
 		//Given
+		setup();
+
 		Member member = createMember();
 		em.persist(member);
 		EducationLevel educationLevel = createEducationLevel();
@@ -219,6 +223,8 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 	@DisplayName("[Success] findAllTechBooks(): TechBook 다 건 조회, 페이징 적용")
 	void findAllTechBooks() {
 		//Given
+		setup();
+
 		Member member = createMember();
 		em.persist(member);
 		EducationLevel educationLevel = createEducationLevel();

--- a/src/test/java/ssammudan/cotree/model/education/level/repository/EducationLevelRepositoryTest.java
+++ b/src/test/java/ssammudan/cotree/model/education/level/repository/EducationLevelRepositoryTest.java
@@ -43,6 +43,8 @@ class EducationLevelRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] save(): EducationLevel 엔티티 저장")
 	void save() {
 		//Given
+		setup();
+
 		EducationLevel educationLevel = createEducationLevel();
 
 		//When
@@ -60,6 +62,8 @@ class EducationLevelRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] findById(): EducationLevel 엔티티 단 건 조회")
 	void findById() {
 		//Given
+		setup();
+
 		EducationLevel educationLevel = createEducationLevel();
 		entityManager.persist(educationLevel);
 		Long id = educationLevel.getId();
@@ -91,6 +95,8 @@ class EducationLevelRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] findByNameIgnoreCase(): EducationLevel 엔티티 단 건 조회")
 	void findByNameIgnoreCase() {
 		//Given
+		setup();
+
 		String name = fixtureMonkey.giveMeOne(String.class);
 		EducationLevel educationLevel = EducationLevel.create(name);
 		entityManager.persist(educationLevel);

--- a/src/test/java/ssammudan/cotree/model/education/level/repository/EducationLevelRepositoryTest.java
+++ b/src/test/java/ssammudan/cotree/model/education/level/repository/EducationLevelRepositoryTest.java
@@ -61,7 +61,8 @@ class EducationLevelRepositoryTest extends DataJpaTestSupporter {
 	void findById() {
 		//Given
 		EducationLevel educationLevel = createEducationLevel();
-		Long id = entityManager.persist(educationLevel).getId();
+		entityManager.persist(educationLevel);
+		Long id = educationLevel.getId();
 		clearEntityContext();
 
 		//When
@@ -91,7 +92,8 @@ class EducationLevelRepositoryTest extends DataJpaTestSupporter {
 	void findByNameIgnoreCase() {
 		//Given
 		String name = fixtureMonkey.giveMeOne(String.class);
-		EducationLevel educationLevel = entityManager.persist(EducationLevel.create(name));
+		EducationLevel educationLevel = EducationLevel.create(name);
+		entityManager.persist(educationLevel);
 		clearEntityContext();
 
 		//When

--- a/src/test/java/ssammudan/cotree/model/education/supporter/DataJpaTestSupporter.java
+++ b/src/test/java/ssammudan/cotree/model/education/supporter/DataJpaTestSupporter.java
@@ -1,10 +1,11 @@
 package ssammudan.cotree.model.education.supporter;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import jakarta.persistence.EntityManager;
 import ssammudan.cotree.global.annotation.RepositoryTest;
 import ssammudan.cotree.model.education.level.repository.EducationLevelRepository;
 import ssammudan.cotree.model.education.techbook.techbook.repository.TechBookRepository;
@@ -22,6 +23,7 @@ import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntr
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 3. 31.    loadingKKamo21       Initial creation
+ * 25. 4. 1.     loadingKKamo21       TestEntityManager -> EntityManager 변경, @BeforeEach 메서드 추가
  */
 @ActiveProfiles("test")
 @RepositoryTest
@@ -33,13 +35,24 @@ public abstract class DataJpaTestSupporter {
 		.build();
 
 	@Autowired
-	protected TestEntityManager entityManager;
+	protected EntityManager entityManager;
 
 	@Autowired
 	protected TechBookRepository techBookRepository;
 
 	@Autowired
 	protected EducationLevelRepository educationLevelRepository;
+
+	@BeforeEach
+	protected void setup() {
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();    //H2 DB 외래키 제약 해제
+
+		entityManager.createNativeQuery("TRUNCATE TABLE member RESTART IDENTITY").executeUpdate();
+		entityManager.createNativeQuery("TRUNCATE TABLE education_level RESTART IDENTITY").executeUpdate();
+		entityManager.createNativeQuery("TRUNCATE TABLE tech_book RESTART IDENTITY").executeUpdate();
+
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();    //H2 DB 외래키 제약 설정
+	}
 
 	@AfterEach
 	protected void clearEntityContext() {

--- a/src/test/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryTest.java
+++ b/src/test/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryTest.java
@@ -78,6 +78,8 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] save(): TechBook 엔티티 저장")
 	void save() {
 		//Given
+		setup();
+
 		Member member = createMember();
 		entityManager.persist(member);
 		EducationLevel educationLevel = createEducationLevel();
@@ -108,6 +110,8 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] findById(): TechBook 엔티티 단 건 조회")
 	void findById() {
 		//Given
+		setup();
+
 		Member member = createMember();
 		entityManager.persist(member);
 		EducationLevel educationLevel = createEducationLevel();
@@ -152,6 +156,8 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 	@DisplayName("[Success] findAllTechBooksByKeyword(): TechBook 다 건 조회, 페이징 적용")
 	void findAllTechBooksByKeyword() {
 		//Given
+		setup();
+
 		Member member = createMember();
 		entityManager.persist(member);
 		EducationLevel educationLevel = createEducationLevel();


### PR DESCRIPTION
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
close #20
  <br/>

## 🔎 작업 내용
- 테스트 코드 수정
  - 기존 반복 테스트(@RepeatTest)의 트랜잭션에서 발생하는 더미 데이터간 충돌 해결을 위해 테이블 초기화 메서드(setup) 추가
  - @BeforeEach 및 더미 데이터 사용 테스트 메서드 내 강제 명시
- TechBook 페이징 목록 조회 기능 구현
  - 리턴 타입 Page, 추후 팀 협의 후 커스텀 템플릿 활용 고려
  - Repository - Service - Controller 기능 구현 및 테스트 코드 작성
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>- messages.properties 적용 이전 고려 삭제