### PR TITLE
[FEAT] : CD 구축을 위한 Dockerfile 및 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,169 @@
+name: deploy
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+      - "src/**"
+      - "build.gradle"
+      - "settings.gradle"
+      - "Dockerfile"
+    branches:
+      - main
+jobs:
+  makeTagAndRelease:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.create_tag.outputs.new_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Tag
+        id: create_tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.create_tag.outputs.new_tag }}
+          release_name: Release ${{ steps.create_tag.outputs.new_tag }}
+          body: ${{ steps.create_tag.outputs.changelog }}
+          draft: false
+          prerelease: false
+
+  buildImageAndPush:
+    name: 도커 이미지 빌드와 푸시
+    needs: makeTagAndRelease
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE_NAME: cotree
+    outputs:
+      DOCKER_IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
+      OWNER_LC: ${{ env.OWNER_LC }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: .env 생성
+        env:
+          DOT_ENV: ${{ secrets.DOT_ENV }}
+        run: echo "$DOT_ENV" > .env
+      - name: Docker Buildx 설치
+        uses: docker/setup-buildx-action@v2
+      - name: 레지스트리 로그인
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: "${{ github.repository_owner }}"
+      - name: 빌드 앤 푸시
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/${{ env.DOCKER_IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ env.OWNER_LC }}/${{ env.DOCKER_IMAGE_NAME }}:cache,mode=max
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.DOCKER_IMAGE_NAME }}:${{ needs.makeTagAndRelease.outputs.tag_name }},
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.DOCKER_IMAGE_NAME }}:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [ buildImageAndPush ]
+    env:
+      DOCKER_IMAGE_NAME: ${{ needs.buildImageAndPush.outputs.DOCKER_IMAGE_NAME }}
+      OWNER_LC: ${{ needs.buildImageAndPush.outputs.OWNER_LC }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: 인스턴스 ID 가져오기
+        id: get_instance_id
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=Team15-ec2-1" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output text)
+          echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+          echo $INSTANCE_ID
+      - name: AWS SSM Send-Command
+        uses: peterkimzz/aws-ssm-send-command@master
+        id: ssm
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          instance-ids: ${{ env.INSTANCE_ID }}
+          working-directory: /
+          comment: Deploy
+          command: |
+            # 공통 변수
+            IMAGE="ghcr.io/${{ env.OWNER_LC }}/${{ env.DOCKER_IMAGE_NAME }}:latest"
+            VOLUME="/gen:/gen"
+            NETWORK="common"
+            HEALTH_ENDPOINT="/actuator/health"
+            TIMEOUT=60
+
+            # 현재 실행 중인 컨테이너 확인
+            if docker ps --format '{{.Names}}' | grep -q "app1_1"; then
+              CURRENT="app1_1"
+              NEXT="app1_2"
+              CURRENT_PORT=8080
+              NEXT_PORT=8081
+            else
+              CURRENT="app1_2"
+              NEXT="app1_1"
+              CURRENT_PORT=8081
+              NEXT_PORT=8080
+            fi
+
+            # 다음 컨테이너 실행
+            echo "Starting new container: $NEXT on port $NEXT_PORT..."
+            docker pull "$IMAGE"
+            docker stop "$NEXT" 2>/dev/null
+            docker rm "$NEXT" 2>/dev/null
+            docker run -d \
+              -v $VOLUME \
+              --network $NETWORK \
+              --name "$NEXT" \
+              -p "$NEXT_PORT":8080 \
+              "$IMAGE"
+
+            # 헬스체크 대기
+            echo "Waiting for health check..."
+            START_TIME=$(date +%s)
+            while true; do
+              CONTENT=$(curl -s http://localhost:$NEXT_PORT$HEALTH_ENDPOINT)
+
+              if [[ "$CONTENT" == *'"status":"UP"'* ]]; then
+                echo "✅ $NEXT is UP!"
+                break
+              fi
+
+              ELAPSED_TIME=$(( $(date +%s) - START_TIME ))
+              if [[ $ELAPSED_TIME -ge $TIMEOUT ]]; then
+                echo "❌ Timeout: $NEXT did not start in $TIMEOUT seconds."
+                docker stop "$NEXT"
+                docker rm "$NEXT"
+                exit 1
+              fi
+
+              echo "⏳ Waiting for $NEXT to be UP..."
+              sleep 5
+            done
+
+            sleep 10 # ha proxy 가 사용하는 dns 캐시 때문에 서비스가 띄워지고도 10초 후에 발견될 수 도 있다. 그래서 기존 서버를 바로 내리지 않는다.
+
+            # 기존 컨테이너 중지 및 제거
+            echo "Stopping old container: $CURRENT"
+            docker stop "$CURRENT" 2>/dev/null
+            docker rm "$CURRENT" 2>/dev/null
+
+            # dangling image 제거
+            docker rmi $(docker images -f "dangling=true" -q) 2>/dev/null
+
+            echo "✅ Deployment complete. Running container: $NEXT on port $NEXT_PORT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# 첫 번째 스테이지: 빌드 스테이지
+FROM gradle:jdk-21-and-23-graal-jammy AS builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 소스 코드와 Gradle 래퍼 복사
+COPY build.gradle .
+COPY settings.gradle .
+COPY gradlew .
+COPY gradle gradle
+
+RUN chmod +x gradlew
+
+# 종속성 설치
+RUN ./gradlew dependencies --no-daemon
+
+# 소스 코드 복사
+COPY src src
+
+# 애플리케이션 빌드
+RUN ./gradlew build --no-daemon -x test
+
+# 두 번째 스테이지: 실행 스테이지
+FROM container-registry.oracle.com/graalvm/jdk:23
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 첫 번째 스테이지에서 빌드된 JAR 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+COPY .env .env
+
+# 실행할 JAR 파일 지정
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,11 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql:11.5.0'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // Jakarta Annotations API & Jakarta Persistence API
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql:11.5.0'
 
     // Querydsl
-    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -23,8 +23,9 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers(POST, "/api/v1/community/board").authenticated()
-				.anyRequest().permitAll()
+			.requestMatchers(GET, "/actuator/health").permitAll()
+			.requestMatchers(POST, "/api/v1/community/board").authenticated()
+			.anyRequest().permitAll()
 		);
 
 		http.csrf(AbstractHttpConfigurer::disable);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     name: CoTree
   config:
     import:
+      - optional:file:.env[.properties]
       - optional:classpath:config/${spring.profiles.active}/application-${spring.profiles.active}_db.yml
       - optional:classpath:config/${spring.profiles.active}/application-${spring.profiles.active}_server.yml
       - optional:classpath:config/${spring.profiles.active}/application-${spring.profiles.active}_auth.yml

--- a/src/main/resources/config/prod/application-prod_db.yml
+++ b/src/main/resources/config/prod/application-prod_db.yml
@@ -6,7 +6,7 @@ spring:
     password: ${RDBMS_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:

--- a/src/main/resources/config/prod/application-prod_db.yml
+++ b/src/main/resources/config/prod/application-prod_db.yml
@@ -6,7 +6,7 @@ spring:
     password: ${RDBMS_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:


### PR DESCRIPTION
**[FEAT] : CD 구축을 위한 Dockerfile 및 배포 설정 추가**

## 📝Part
- [ ] BE
- [ ] FE
- [x] Infra

<br/>

## #️⃣연관된 이슈
#28

<br/>

## 🔎 작업 내용
- **Dockerfile** 및 **deploy.yml** 파일 추가하여 배포 자동화와 CD 파이프라인 구축을 위한 설정 적용

## 수정 내용
- **application-prod_db.yml**에서 `ddl-auto: update`로 수정하여 서버 실행 시 자동으로 테이블 및 데이터 생성 구현
- **application.yml**에 `config.import - optional:file:.env[.properties]` 추가하여 서버에서 자동으로 .env 파일을 적용하도록 설정
- **build.gradle**에서 QueryDSL 버전 5.0.0에서 5.1.9로 업그레이드하여 소나큐브 지적 및 배포 자동화 오류 해결
- **spring-boot-starter-actuator** 의존성 추가하여 애플리케이션 상태 모니터링 및 `/actuator/health` API를 통한 정상 작동 여부 확인
- **SecurityConfig**에 `/actuator/health` 접근 허용 설정 추가하여 누구나 해당 엔드포인트에 접근 가능하도록 설정


<br/>

## 💬 집중 리뷰 요구
CD 자동화 설정 중 발생한 부분을 임의로 수정했습니다. 수정된 내용 중 문제가 될 수 있는 부분이나 개선이 필요한 부분이 있으면 피드백 부탁드립니다. 수정 사항을 인지해 주셨으면 좋겠습니다.
<br/>
