### PR TITLE
[FEAT] #RRDC-1, #CBDC-1 댓글 작성 기능 구현

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
@@ -1,0 +1,54 @@
+package ssammudan.cotree.domain.comment.controller;
+
+import java.security.Principal;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ssammudan.cotree.domain.comment.dto.CommentRequest;
+import ssammudan.cotree.domain.comment.service.CommentService;
+import ssammudan.cotree.global.response.BaseResponse;
+import ssammudan.cotree.global.response.SuccessCode;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.controller
+ * FileName    : CommentController
+ * Author      : Baekgwa
+ * Date        : 2025-04-02
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-02     Baekgwa               Initial creation
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/comment")
+@RequiredArgsConstructor
+@Tag(name = "Comment Controller", description = "댓글 관련 API")
+public class CommentController {
+	private final CommentService commentService;
+
+	// todo : 로그인 회원만 접근 가능하도록, security 인가 경로 추가 필요.
+	@PostMapping()
+	@Operation(summary = "댓글/대댓글 작성")
+	@SecurityRequirement(name = "bearerAuth")
+	public BaseResponse<Void> postNewComment(
+			@Valid @RequestBody CommentRequest.PostComment postComment,
+			Principal principal
+	) {
+		// todo : memberId securityContext 로부터 받도록 주석 처리 해제 필요.
+		// String memberId = principal.getName();
+		String memberId = "1";
+		commentService.postNewComment(postComment, memberId);
+		return BaseResponse.success(SuccessCode.COMMENT_CREATE_SUCCESS);
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import ssammudan.cotree.domain.comment.dto.CommentRequest;
 import ssammudan.cotree.domain.comment.service.CommentService;
 import ssammudan.cotree.global.response.BaseResponse;
@@ -29,7 +28,6 @@ import ssammudan.cotree.global.response.SuccessCode;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-04-02     Baekgwa               Initial creation
  */
-@Slf4j
 @RestController
 @RequestMapping("/api/v1/comment")
 @RequiredArgsConstructor

--- a/src/main/java/ssammudan/cotree/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/dto/CommentRequest.java
@@ -1,8 +1,8 @@
 package ssammudan.cotree.domain.comment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,7 +27,7 @@ public class CommentRequest {
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class PostComment {
-		@NotBlank(message = "댓글 내용은 필수 입니다.")
+		@Size(min = 1, max = 1000, message = "내용은 1자 이상 1000자 이하로 입력해주세요.")
 		private String content;
 
 		@NotNull(message = "댓글 카테고리는 필수 입니다.")

--- a/src/main/java/ssammudan/cotree/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/dto/CommentRequest.java
@@ -1,0 +1,42 @@
+package ssammudan.cotree.domain.comment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.dto
+ * FileName    : CommentRequest
+ * Author      : Baekgwa
+ * Date        : 2025-04-02
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-02     Baekgwa               Initial creation
+ */
+public class CommentRequest {
+
+	private CommentRequest() {
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class PostComment {
+		@NotBlank(message = "댓글 내용은 필수 입니다.")
+		private String content;
+
+		@NotNull(message = "댓글 카테고리는 필수 입니다.")
+		@Schema(example = "RESUME")
+		private CommentCategory category;
+
+		@NotNull(message = "댓글을 달 Item 의 id 값은 필수입니다.")
+		private Long whereId;
+
+		private Long commentId;
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/comment/service/CommentService.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/service/CommentService.java
@@ -1,0 +1,19 @@
+package ssammudan.cotree.domain.comment.service;
+
+import ssammudan.cotree.domain.comment.dto.CommentRequest;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.service
+ * FileName    : CommentService
+ * Author      : Baekgwa
+ * Date        : 2025-04-02
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-02     Baekgwa               Initial creation
+ */
+public interface CommentService {
+
+	void postNewComment(final CommentRequest.PostComment postComment, final String memberId);
+}

--- a/src/main/java/ssammudan/cotree/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,70 @@
+package ssammudan.cotree.domain.comment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.comment.dto.CommentRequest;
+import ssammudan.cotree.global.error.GlobalException;
+import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.model.common.comment.entity.Comment;
+import ssammudan.cotree.model.common.comment.repository.CommentRepository;
+import ssammudan.cotree.model.community.community.entity.Community;
+import ssammudan.cotree.model.community.community.repository.CommunityRepository;
+import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.member.member.repository.MemberRepository;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.service
+ * FileName    : CommentServiceImpl
+ * Author      : Baekgwa
+ * Date        : 2025-04-02
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-02     Baekgwa               Initial creation
+ */
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+	private final CommentRepository commentRepository;
+	private final MemberRepository memberRepository;
+	private final CommunityRepository communityRepository;
+
+	@Transactional
+	@Override
+	public void postNewComment(final CommentRequest.PostComment postComment, final String memberId) {
+
+		Member commentAuthor = memberRepository.findById(memberId)
+				.orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_MEMBER));
+
+		switch (postComment.getCategory()) {
+			case COMMUNITY -> {
+				//커뮤니티 글 조회
+				Community targetCommunity = communityRepository.findById(postComment.getWhereId())
+						.orElseThrow(() -> new GlobalException(ErrorCode.POST_COMMENT_FAIL_COMMUNITY_NOTFOUND));
+
+				//대댓글 이라면, 댓글 정보 조회
+				Comment parrentCommunity = null;
+				if (postComment.getCommentId() != null) {
+					parrentCommunity = commentRepository.findById(postComment.getCommentId())
+							.orElseThrow(
+									() -> new GlobalException(ErrorCode.POST_COMMENT_FAIL_PARENT_COMMENT_NOTFOUND));
+				}
+
+				//신규 댓글 저장
+				commentRepository.save(
+						Comment.createNewCommunityComment(
+								commentAuthor,
+								targetCommunity,
+								parrentCommunity,
+								postComment.getContent()));
+			}
+			// case RESUME -> {
+			//
+			// }
+		}
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/comment/type/CommentCategory.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/type/CommentCategory.java
@@ -1,0 +1,24 @@
+package ssammudan.cotree.domain.comment.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.type
+ * FileName    : CommentCategory
+ * Author      : Baekgwa
+ * Date        : 2025-04-02
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-02     Baekgwa               Initial creation
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CommentCategory {
+	RESUME("이력서 댓글"),
+	COMMUNITY("커뮤니티 글 댓글");
+
+	private final String description;
+}

--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -77,7 +77,7 @@ public class CommunityController {
 	}
 
 	@GetMapping("/board/{boardId}")
-	@Operation(summary = "커뮤니티 글 목록 조회")
+	@Operation(summary = "커뮤니티 글 상세 조회")
 	@SecurityRequirement(name = "bearerAuth")
 	public BaseResponse<CommunityResponse.BoardDetail> getBoardDetail(
 			@PathVariable(value = "boardId") Long boardId,

--- a/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
@@ -36,7 +36,9 @@ public enum ErrorCode {
 
 	//Comment: 7001 ~ 8000
 	POST_COMMENT_FAIL_COMMUNITY_NOTFOUND(HttpStatus.BAD_REQUEST, "7001", "커뮤니티 댓글 작성 실패. 잘못된 글 ID 입니다."),
-	POST_COMMENT_FAIL_PARENT_COMMENT_NOTFOUND(HttpStatus.BAD_REQUEST, "7001", "커뮤니티 대댓글 작성 실패. 잘못된 댓글 ID 입니다."),
+	POST_COMMENT_FAIL_RESUME_NOTFOUND(HttpStatus.BAD_REQUEST, "7002", "커뮤니티 댓글 작성 실패. 잘못된 글 ID 입니다."),
+	POST_COMMENT_FAIL_PARENT_COMMENT_NOTFOUND(HttpStatus.BAD_REQUEST, "7003", "대댓글 작성 실패. 잘못된 댓글 ID 입니다."),
+	POST_COMMENT_FAIL_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "7004", "댓글 작성 실패. 잘못된 카테고리 입니다."),
 
 	//${}: 8001 ~ 9000
 

--- a/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
@@ -33,7 +33,9 @@ public enum ErrorCode {
 	//S3: 6001 ~ 7000
 	FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "6001", "파일 업로드 실패, 재시도 혹은 관리자 문의해주세요."),
 
-	//${}: 7001 ~ 8000
+	//Comment: 7001 ~ 8000
+	POST_COMMENT_FAIL_COMMUNITY_NOTFOUND(HttpStatus.BAD_REQUEST, "7001", "커뮤니티 댓글 작성 실패. 잘못된 글 ID 입니다."),
+	POST_COMMENT_FAIL_PARENT_COMMENT_NOTFOUND(HttpStatus.BAD_REQUEST, "7001", "커뮤니티 대댓글 작성 실패. 잘못된 댓글 ID 입니다."),
 
 	//${}: 8001 ~ 9000
 

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -32,7 +32,8 @@ public enum SuccessCode {
 	//S3 Upload
 	S3_FILE_UPLOAD_SUCCESS(HttpStatus.CREATED, "201", "파일 업로드 성공."),
 
-	//${}: 7001 ~ 8000
+	//Comment:
+	COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "댓글 작성 성공"),
 
 	//${}: 8001 ~ 9000
 

--- a/src/main/java/ssammudan/cotree/model/common/comment/entity/Comment.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/entity/Comment.java
@@ -9,7 +9,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import ssammudan.cotree.global.entity.BaseEntity;
 import ssammudan.cotree.model.community.community.entity.Community;
 import ssammudan.cotree.model.member.member.entity.Member;
@@ -29,6 +32,7 @@ import ssammudan.cotree.model.recruitment.resume.resume.entity.Resume;
 @Entity
 @Getter
 @Table(name = "comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
 	@Id
@@ -42,7 +46,7 @@ public class Comment extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
-	private Member member;
+	private Member author;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "community_id")
@@ -54,4 +58,36 @@ public class Comment extends BaseEntity {
 
 	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
 	private String content;
+
+	@Builder
+	private Comment(Comment parentComment, Member author, Community community, Resume resume, String content) {
+		this.parentComment = parentComment;
+		this.author = author;
+		this.community = community;
+		this.resume = resume;
+		this.content = content;
+	}
+
+	public static Comment createNewCommunityComment(Member author, Community community, Comment parrentComment,
+			String content) {
+		return Comment
+				.builder()
+				.parentComment(parrentComment)
+				.author(author)
+				.community(community)
+				.resume(null)
+				.content(content)
+				.build();
+	}
+
+	public static Comment createNewResumeComment(Member author, Resume resume, Comment parrentComment, String content) {
+		return Comment
+				.builder()
+				.parentComment(parrentComment)
+				.author(author)
+				.community(null)
+				.resume(resume)
+				.content(content)
+				.build();
+	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#49 
  <br/>

## 🔎 작업 내용
- `Resume` (이력서), `Community` (커뮤니티 게시글) 에 댓글을 남기는 기능을 추가하였습니다.
- JPA 를 사용하였습니다.
- 로그인 정보는 하드코딩으로 진행되어있습니다.
  - 추후, 로그인 기능 merge 시, 업데이트 예정입니다.
- 대댓글을 저장할 때, parent_id 만 있으면 사실 조회가 가능하지만, 추후 조회시 편의성을 위해 각 item 의 id 를 같이 넣어두었습니다.
  - 추후 기능 구현에 따라, 저장 로직이 변경될 수 있습니다.
  - 또한 단방향 매핑만 추가되어있는데, 아마 삭제 기능이나 조회 기능 개발하면서 양방향 매핑이 추가될 수 있습니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>