### PR TITLE
[FEAT] #PT-2 프로젝트 생성

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -30,7 +30,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * 2025. 4. 2.     sangxxjin               Initial creation
  */
 @RestController
-@RequestMapping("/api/v1/project")
+@RequestMapping("/api/v1/project/team")
 @RequiredArgsConstructor
 @Tag(name = "Proejct Controller", description = "프로젝트 생성 API")
 public class ProjectController {

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -41,7 +41,7 @@ public class ProjectController {
 	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
 	public BaseResponse<ProjectCreateResponse> createProject(
 		@RequestPart("request") @Valid ProjectCreateRequest request,
-		@RequestPart(value = "projectImageUrl", required = false) MultipartFile projectImage) {
+		@RequestPart(value = "projectImage", required = false) MultipartFile projectImage) {
 		//todo: 현재 회원 정보 하드 코딩 -> 로그인한 member 넘기게 수정 예정
 		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, "1");
 

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -1,0 +1,49 @@
+package ssammudan.cotree.domain.project.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
+import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
+import ssammudan.cotree.global.response.BaseResponse;
+import ssammudan.cotree.global.response.SuccessCode;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.controller
+ * FileName    : ProjectController
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+@RestController
+@RequestMapping("/api/v1/project")
+@RequiredArgsConstructor
+@Tag(name = "Proejct Controller", description = "프로젝트 생성 API")
+public class ProjectController {
+	private final ProjectServiceImpl projectServiceImpl;
+
+	@PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "프로젝트 생성")
+	public BaseResponse<ProjectCreateResponse> createProject(
+		@RequestPart("request") @Valid ProjectCreateRequest request,
+		@RequestPart(value = "projectImageUrl", required = false) MultipartFile projectImage) {
+		//todo: 현재 회원 정보 하드 코딩 -> 로그인한 member 넘기게 수정 예정
+		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, "1");
+
+		return BaseResponse.success(SuccessCode.PROJECT_CREATE_SUCCESS, response);
+	}
+}
+

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,8 @@ public class ProjectController {
 	private final ProjectServiceImpl projectServiceImpl;
 
 	@PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	@Operation(summary = "프로젝트 생성")
+	@Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
+	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
 	public BaseResponse<ProjectCreateResponse> createProject(
 		@RequestPart("request") @Valid ProjectCreateRequest request,
 		@RequestPart(value = "projectImageUrl", required = false) MultipartFile projectImage) {

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateRequest.java
@@ -1,0 +1,41 @@
+package ssammudan.cotree.domain.project.dto;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : ProjectRequest
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 1개 이상의 테크스택과, 포지션별 인원수를 요구함
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+public record ProjectCreateRequest(
+	@NotBlank @Size(max = 20) String title,
+	@NotBlank @Size(min = 1, max = 500) String description,
+	@NotBlank @Email String contact,
+	@NotBlank String partnerType,
+	@NotEmpty @Size(min = 1, max = 9) Set<Long> techStackIds,
+	@NotEmpty Map<Long, @NotNull @Min(1) @Max(10) Integer> recruitmentPositions,
+	@NotNull @PastOrPresent @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+	@Nullable @FutureOrPresent @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+) {
+}

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateResponse.java
@@ -1,0 +1,27 @@
+package ssammudan.cotree.domain.project.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import ssammudan.cotree.model.project.project.entity.Project;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : ProjectCreateResponse
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 생성한 project의 id만 넘김
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public record ProjectCreateResponse(
+	Long projectId
+) {
+	public static ProjectCreateResponse from(Project project) {
+		return ProjectCreateResponse.builder()
+			.projectId(project.getId())
+			.build();
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -1,0 +1,22 @@
+package ssammudan.cotree.domain.project.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
+import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.service
+ * FileName    : ProjectService
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+
+public interface ProjectService {
+	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
+}

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -63,7 +63,7 @@ public class ProjectServiceImpl implements ProjectService {
 		List<DevelopmentPosition> devPositions = getDevelopmentPositions(request);
 
 		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 
 		Project project = Project.create(member, request, savedImageUrl);
 

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -1,0 +1,93 @@
+package ssammudan.cotree.domain.project.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
+import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.global.error.GlobalException;
+import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.infra.s3.S3Directory;
+import ssammudan.cotree.infra.s3.S3Uploader;
+import ssammudan.cotree.model.common.developmentposition.entity.DevelopmentPosition;
+import ssammudan.cotree.model.common.developmentposition.repository.DevelopmentPositionRepository;
+import ssammudan.cotree.model.common.techstack.entity.TechStack;
+import ssammudan.cotree.model.common.techstack.repository.TechStackRepository;
+import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.member.member.repository.MemberRepository;
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
+import ssammudan.cotree.model.project.devposition.repository.ProjectDevPositionRepository;
+import ssammudan.cotree.model.project.project.entity.Project;
+import ssammudan.cotree.model.project.project.repository.ProjectRepository;
+import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
+import ssammudan.cotree.model.project.techstack.repository.ProjectTechStackRepository;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.service
+ * FileName    : ProjectService
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin          create project 구현
+ */
+@Service
+@RequiredArgsConstructor
+public class ProjectServiceImpl implements ProjectService {
+	private final TechStackRepository techStackRepository;
+	private final DevelopmentPositionRepository developmentPositionRepository;
+	private final MemberRepository memberRepository;
+	private final ProjectTechStackRepository projectTechStackRepository;
+	private final ProjectRepository projectRepository;
+	private final ProjectDevPositionRepository projectDevPositionRepository;
+	private final S3Uploader s3Uploader;
+
+	@Override
+	@Transactional
+	public ProjectCreateResponse create(@Valid ProjectCreateRequest request, MultipartFile projectImage,
+		String memberId) {
+
+		String savedImageUrl = Optional.ofNullable(projectImage)
+			.map(img -> s3Uploader.upload(memberId, img, S3Directory.PROJECT).getSaveUrl())
+			.orElse(null);
+
+		List<TechStack> techStacks = getTechStacks(request);
+		List<DevelopmentPosition> devPositions = getDevelopmentPositions(request);
+
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_FOUND_MEMBER));
+
+		Project project = Project.create(member, request, savedImageUrl);
+
+		List<ProjectTechStack> projectTechStacks = techStacks.stream()
+			.map(techStack -> ProjectTechStack.create(project, techStack))
+			.toList();
+
+		List<ProjectDevPosition> projectDevPositions = devPositions.stream()
+			.map(devPosition -> ProjectDevPosition.create(project, devPosition,
+				request.recruitmentPositions().get(devPosition.getId())))
+			.toList();
+
+		projectRepository.save(project);
+		projectTechStackRepository.saveAll(projectTechStacks);
+		projectDevPositionRepository.saveAll(projectDevPositions);
+
+		return ProjectCreateResponse.from(project);
+	}
+
+	private List<TechStack> getTechStacks(ProjectCreateRequest request) {
+		return techStackRepository.findByIds(request.techStackIds());
+	}
+
+	private List<DevelopmentPosition> getDevelopmentPositions(ProjectCreateRequest request) {
+		return developmentPositionRepository.findByIds(request.recruitmentPositions().keySet());
+	}
+}

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -24,6 +24,7 @@ public enum SuccessCode {
 	RESUME_DETAIL_SUCCESS(HttpStatus.OK, "200", "이력서 상세 조회를 성공하였습니다."),
 
 	//Project
+	PROJECT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "프로젝트 생성 성공"),
 
 	//Community
 	COMMUNITY_BOARD_CREATE_SUCCESS(HttpStatus.CREATED, "201", "글 작성 성공"),

--- a/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
+++ b/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
@@ -18,7 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum S3Directory {
 	USER_PROFILE("user/profile/", false),
-	COMMUNITY_BOARD("community/board/", true);
+	COMMUNITY_BOARD("community/board/", true),
+	PROJECT("project/", false);
 
 	private final String path;
 	private final boolean isMultiFile;

--- a/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
+++ b/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 public enum S3Directory {
 	USER_PROFILE("user/profile/", false),
 	COMMUNITY_BOARD("community/board/", true),
-	PROJECT("project/", false);
+	PROJECT("project/team", false);
 
 	private final String path;
 	private final boolean isMultiFile;

--- a/src/main/java/ssammudan/cotree/model/project/devposition/entity/ProjectDevPosition.java
+++ b/src/main/java/ssammudan/cotree/model/project/devposition/entity/ProjectDevPosition.java
@@ -9,7 +9,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import ssammudan.cotree.model.common.developmentposition.entity.DevelopmentPosition;
 import ssammudan.cotree.model.project.project.entity.Project;
 
@@ -23,10 +27,14 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04--2     sangxxjin             add builder
  */
 @Entity
 @Getter
 @Table(name = "project_devPosition")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectDevPosition {
 
 	@Id
@@ -44,4 +52,12 @@ public class ProjectDevPosition {
 
 	@Column(name = "amount", nullable = false)
 	private Integer amount;
+
+	public static ProjectDevPosition create(Project project, DevelopmentPosition developmentPosition, Integer amount) {
+		return ProjectDevPosition.builder()
+			.project(project)
+			.developmentPosition(developmentPosition)
+			.amount(amount)
+			.build();
+	}
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
@@ -11,7 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.global.entity.BaseEntity;
 import ssammudan.cotree.model.member.member.entity.Member;
 
@@ -25,10 +30,14 @@ import ssammudan.cotree.model.member.member.entity.Member;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04--2     sangxxjin             add builder
  */
 @Entity
 @Getter
 @Table(name = "project")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Project extends BaseEntity {
 
 	@Id
@@ -66,4 +75,19 @@ public class Project extends BaseEntity {
 
 	@Column(name = "view_count", nullable = false)
 	private Integer viewCount;
+
+	public static Project create(Member member, ProjectCreateRequest request, String savedImageUrl) {
+		return Project.builder()
+			.member(member)
+			.title(request.title())
+			.description(request.description())
+			.contact(request.contact())
+			.projectImageUrl(savedImageUrl)
+			.partnerType(request.partnerType())
+			.isOpen(true)
+			.startDate(request.startDate())
+			.endDate(request.endDate())
+			.viewCount(0)
+			.build();
+	}
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
@@ -65,7 +65,8 @@ public class Project extends BaseEntity {
 	private String partnerType;
 
 	@Column(name = "is_open", nullable = false)
-	private Boolean isOpen;
+	@Builder.Default
+	private Boolean isOpen = true;
 
 	@Column(name = "start_date", nullable = false)
 	private LocalDate startDate;
@@ -74,7 +75,8 @@ public class Project extends BaseEntity {
 	private LocalDate endDate;
 
 	@Column(name = "view_count", nullable = false)
-	private Integer viewCount;
+	@Builder.Default
+	private Integer viewCount = 0;
 
 	public static Project create(Member member, ProjectCreateRequest request, String savedImageUrl) {
 		return Project.builder()
@@ -84,10 +86,8 @@ public class Project extends BaseEntity {
 			.contact(request.contact())
 			.projectImageUrl(savedImageUrl)
 			.partnerType(request.partnerType())
-			.isOpen(true)
 			.startDate(request.startDate())
 			.endDate(request.endDate())
-			.viewCount(0)
 			.build();
 	}
 }

--- a/src/main/java/ssammudan/cotree/model/project/techstack/entity/ProjectTechStack.java
+++ b/src/main/java/ssammudan/cotree/model/project/techstack/entity/ProjectTechStack.java
@@ -9,7 +9,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import ssammudan.cotree.model.common.techstack.entity.TechStack;
 import ssammudan.cotree.model.project.project.entity.Project;
 
@@ -23,10 +27,14 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04--2     sangxxjin             add builder
  */
 @Entity
 @Getter
 @Table(name = "project_techStack")
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectTechStack {
 
 	@Id
@@ -41,4 +49,11 @@ public class ProjectTechStack {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "tech_stack_id", nullable = false)
 	private TechStack techStack;
+
+	public static ProjectTechStack create(Project project, TechStack techStack) {
+		return ProjectTechStack.builder()
+			.project(project)
+			.techStack(techStack)
+			.build();
+	}
 }

--- a/src/test/java/ssammudan/cotree/domain/project/controller/ProjectControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/project/controller/ProjectControllerTest.java
@@ -1,0 +1,17 @@
+package ssammudan.cotree.domain.project.controller;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.controller
+ * FileName    : ProjectControllerTest
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+class ProjectControllerTest {
+	//todo: 개발 예정
+
+}

--- a/src/test/java/ssammudan/cotree/domain/project/service/ProjectServiceImplTest.java
+++ b/src/test/java/ssammudan/cotree/domain/project/service/ProjectServiceImplTest.java
@@ -1,0 +1,16 @@
+package ssammudan.cotree.domain.project.service;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.service
+ * FileName    : ProjectServiceImplTest
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 2.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 2.     sangxxjin               Initial creation
+ */
+class ProjectServiceImplTest {
+	//todo: 개발 예정
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#42 
  <br/>

## 🔎 작업 내용
- 프로젝트 생성 API 구현
  - member, security 적용되면 controller에서 로그인 한 member 받아올 예정
- 빌더 패턴 적용
- S3Directory enum class에 project 경로 추가
- 이미지 파일을 request에 담아서 처리가 불가능하여 controller에서 따로 받게 구현(포스트맨 사용 양식 이미지 첨부)
  - request의 Content-Type을 application/json으로 지정해야 합니다.
  <br/>


## 📈이미지 첨부 (필요시)
![스크린샷 2025-04-02 17 21 29](https://github.com/user-attachments/assets/a4a83740-7a0c-4683-b8b5-6e985daca3fe)
  <br/>



