### PR TITLE
[REFACTOR] : Security 인가 path 설정 및 누락 pord profile 설정 추가

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
@@ -1,19 +1,18 @@
 package ssammudan.cotree.domain.comment.controller;
 
-import java.security.Principal;
-
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.comment.dto.CommentRequest;
 import ssammudan.cotree.domain.comment.service.CommentService;
+import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
@@ -35,17 +34,13 @@ import ssammudan.cotree.global.response.SuccessCode;
 public class CommentController {
 	private final CommentService commentService;
 
-	// todo : 로그인 회원만 접근 가능하도록, security 인가 경로 추가 필요.
-	@PostMapping()
+	@PostMapping
 	@Operation(summary = "댓글/대댓글 작성")
-	@SecurityRequirement(name = "bearerAuth")
 	public BaseResponse<Void> postNewComment(
 			@Valid @RequestBody CommentRequest.PostComment postComment,
-			Principal principal
+			@AuthenticationPrincipal CustomUser customUser
 	) {
-		// todo : memberId securityContext 로부터 받도록 주석 처리 해제 필요.
-		// String memberId = principal.getName();
-		String memberId = "1";
+		String memberId = customUser.getId();
 		commentService.postNewComment(postComment, memberId);
 		return BaseResponse.success(SuccessCode.COMMENT_CREATE_SUCCESS);
 	}

--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -1,9 +1,8 @@
 package ssammudan.cotree.domain.community.controller;
 
-import java.security.Principal;
-
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +20,7 @@ import ssammudan.cotree.domain.community.dto.CommunityResponse;
 import ssammudan.cotree.domain.community.service.CommunityService;
 import ssammudan.cotree.domain.community.type.SearchBoardCategory;
 import ssammudan.cotree.domain.community.type.SearchBoardSort;
+import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
@@ -47,11 +46,11 @@ public class CommunityController {
 
 	@PostMapping("/board")
 	@Operation(summary = "커뮤니티 글 작성")
-	@SecurityRequirement(name = "bearerAuth")
 	public BaseResponse<Void> createNewBoard(
 			@Valid @RequestBody CommunityRequest.CreateBoard createBoard,
-			Principal principal) {
-		String memberId = principal.getName();
+			@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = customUser.getName();
 
 		communityService.createNewBoard(createBoard, memberId);
 		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS);
@@ -59,16 +58,15 @@ public class CommunityController {
 
 	@GetMapping("/board")
 	@Operation(summary = "커뮤니티 글 목록 조회")
-	@SecurityRequirement(name = "bearerAuth")
 	public BaseResponse<PageResponse<CommunityResponse.BoardListDetail>> getBoardList(
 			@RequestParam(value = "page", defaultValue = "0", required = false) int page,
 			@RequestParam(value = "size", defaultValue = "5", required = false) int size,
 			@RequestParam(value = "sort", defaultValue = "LATEST", required = false) SearchBoardSort sort,
 			@RequestParam(value = "category", defaultValue = "TOTAL", required = false) SearchBoardCategory category,
 			@RequestParam(value = "keyword", defaultValue = "", required = false) String keyword,
-			Principal principal
+			@AuthenticationPrincipal CustomUser customUser
 	) {
-		String memberId = (principal != null) ? principal.getName() : null;
+		String memberId = (customUser != null) ? customUser.getId() : null;
 		Pageable pageable = PageRequest.of(page, size);
 		PageResponse<CommunityResponse.BoardListDetail> boardList =
 				communityService.getBoardList(pageable, sort, category, keyword, memberId);
@@ -78,12 +76,11 @@ public class CommunityController {
 
 	@GetMapping("/board/{boardId}")
 	@Operation(summary = "커뮤니티 글 상세 조회")
-	@SecurityRequirement(name = "bearerAuth")
 	public BaseResponse<CommunityResponse.BoardDetail> getBoardDetail(
 			@PathVariable(value = "boardId") Long boardId,
-			Principal principal
+			@AuthenticationPrincipal CustomUser customUser
 	) {
-		String memberId = (principal != null) ? principal.getName() : null;
+		String memberId = (customUser != null) ? customUser.getId() : null;
 		CommunityResponse.BoardDetail boardDetail = communityService.getBoardDetail(boardId, memberId);
 		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS, boardDetail);
 	}

--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -50,7 +50,7 @@ public class CommunityController {
 			@Valid @RequestBody CommunityRequest.CreateBoard createBoard,
 			@AuthenticationPrincipal CustomUser customUser
 	) {
-		String memberId = customUser.getName();
+		String memberId = customUser.getId();
 
 		communityService.createNewBoard(createBoard, memberId);
 		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS);

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package ssammudan.cotree.domain.project.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
+import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
@@ -32,7 +34,7 @@ import ssammudan.cotree.global.response.SuccessCode;
 @RestController
 @RequestMapping("/api/v1/project/team")
 @RequiredArgsConstructor
-@Tag(name = "Proejct Controller", description = "프로젝트 생성 API")
+@Tag(name = "Project Controller", description = "프로젝트 생성 API")
 public class ProjectController {
 	private final ProjectServiceImpl projectServiceImpl;
 
@@ -40,10 +42,12 @@ public class ProjectController {
 	@Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
 	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
 	public BaseResponse<ProjectCreateResponse> createProject(
-		@RequestPart("request") @Valid ProjectCreateRequest request,
-		@RequestPart(value = "projectImage", required = false) MultipartFile projectImage) {
-		//todo: 현재 회원 정보 하드 코딩 -> 로그인한 member 넘기게 수정 예정
-		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, "1");
+			@RequestPart("request") @Valid ProjectCreateRequest request,
+			@RequestPart(value = "projectImage", required = false) MultipartFile projectImage,
+			@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = customUser.getId();
+		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, memberId);
 
 		return BaseResponse.success(SuccessCode.PROJECT_CREATE_SUCCESS, response);
 	}

--- a/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
@@ -1,11 +1,11 @@
 package ssammudan.cotree.domain.resume.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +16,7 @@ import ssammudan.cotree.domain.resume.dto.ResumeCreateRequest;
 import ssammudan.cotree.domain.resume.dto.ResumeCreateResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeDetailResponse;
 import ssammudan.cotree.domain.resume.service.ResumeService;
+import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
@@ -41,18 +42,18 @@ public class ResumeController {
 	@Operation(summary = "이력서 작성", description = "이력서를 작성합니다.")
 	@PostMapping
 	public BaseResponse<ResumeCreateResponse> register(
-		@Valid @RequestBody ResumeCreateRequest request,
-		@RequestParam("id") String dummyMemberId
+			@Valid @RequestBody ResumeCreateRequest request,
+			@AuthenticationPrincipal CustomUser customUser
 	) {
-		// todo 추후 수정
-		ResumeCreateResponse response = resumeService.register(request, dummyMemberId);
+		String memberId = customUser.getId();
+		ResumeCreateResponse response = resumeService.register(request, memberId);
 		return BaseResponse.success(SuccessCode.RESUME_CREATE_SUCCESS, response);
 	}
 
 	@Operation(summary = "이력서 상세 조회", description = "이력서 상세를 조회합니다.")
 	@GetMapping("/{id}")
 	public BaseResponse<ResumeDetailResponse> detail(
-		@PathVariable(name = "id") Long id
+			@PathVariable(name = "id") Long id
 	) {
 		return BaseResponse.success(SuccessCode.RESUME_DETAIL_SUCCESS, resumeService.detail(id));
 	}

--- a/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
@@ -1,11 +1,11 @@
 package ssammudan.cotree.domain.resume.controller;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +16,6 @@ import ssammudan.cotree.domain.resume.dto.ResumeCreateRequest;
 import ssammudan.cotree.domain.resume.dto.ResumeCreateResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeDetailResponse;
 import ssammudan.cotree.domain.resume.service.ResumeService;
-import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
@@ -43,10 +42,10 @@ public class ResumeController {
 	@PostMapping
 	public BaseResponse<ResumeCreateResponse> register(
 			@Valid @RequestBody ResumeCreateRequest request,
-			@AuthenticationPrincipal CustomUser customUser
+			@RequestParam("id") String dummyMemberId
 	) {
-		String memberId = customUser.getId();
-		ResumeCreateResponse response = resumeService.register(request, memberId);
+		// todo 추후 수정
+		ResumeCreateResponse response = resumeService.register(request, dummyMemberId);
 		return BaseResponse.success(SuccessCode.RESUME_CREATE_SUCCESS, response);
 	}
 

--- a/src/main/java/ssammudan/cotree/domain/upload/controller/FileUploadController.java
+++ b/src/main/java/ssammudan/cotree/domain/upload/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package ssammudan.cotree.domain.upload.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -8,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 import ssammudan.cotree.infra.s3.S3Directory;
@@ -36,13 +38,10 @@ public class FileUploadController {
 	@PostMapping("/upload")
 	public BaseResponse<S3UploadResult> uploadFile(
 			@RequestParam("file") MultipartFile file,
-			@RequestParam("directory") S3Directory directory
-			// ,Principal principal //todo : 로그인 한 사용자만 업로드 가능
+			@RequestParam("directory") S3Directory directory,
+			@AuthenticationPrincipal CustomUser customUser
 	) {
-		//todo : 로그인한 회원 ID 가져오도록
-		// String memberId = principal.getName();
-		// 현재는 하드코딩 진행 됨.
-		String memberId = "random_uuid";
+		String memberId = customUser.getId();
 		S3UploadResult result = s3Uploader.upload(memberId, file, directory);
 		return BaseResponse.success(SuccessCode.S3_FILE_UPLOAD_SUCCESS, result);
 	}

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
 						// 해당 없음. 모두 인증 필요
 
 						// Resume Domain
-						.requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
+						// .requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
 
 						// Project Domain
 						// 해당 없음. 모두 인증 필요

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.global.config;
 
+import static org.springframework.http.HttpMethod.*;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -40,36 +42,65 @@ public class SecurityConfig {
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 		http
-			// ✅ 보안 관련 설정 (CSRF, CORS, 세션)
-			.csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화 (JWT 사용 시 불필요)
-			.cors(cors -> corsConfigurationSource()) // CORS 설정 적용
-			.sessionManagement(
-				session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 방식)
+				// ✅ 보안 관련 설정 (CSRF, CORS, 세션)
+				.csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화 (JWT 사용 시 불필요)
+				.cors(cors -> corsConfigurationSource()) // CORS 설정 적용
+				.sessionManagement(
+						session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 방식)
 
-			// ✅ 필터 설정 (JWT 인증 필터 → UsernamePasswordAuthenticationFilter)
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+				// ✅ 필터 설정 (JWT 인증 필터 → UsernamePasswordAuthenticationFilter)
+				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
-			// ✅ 인증 및 접근 권한 설정
-			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers("/h2-console/**")
-				.permitAll() // H2 콘솔 허용
-				.requestMatchers("/error", "/favicon.ico")
-				.permitAll() // 프론트엔드에서 적용될 예외 포인트 설정
-				.requestMatchers("/api/v1/member/signup", "/api/v1/member/signin")
-				.permitAll() // 로그인 & 회원가입 허용
-				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html")
-				.permitAll() // Swagger 문서 접근 허용
-				.anyRequest()
-				.authenticated()) // 그 외 요청은 인증 필요
+				// ✅ 인증 및 접근 권한 설정
+				.authorizeHttpRequests(authorize -> authorize
+						// H2 콘솔 허용
+						.requestMatchers("/h2-console/**").permitAll()
+						// 프론트엔드에서 적용될 예외 포인트 설정
+						.requestMatchers("/error", "/favicon.ico").permitAll()
+						// Swagger 문서 접근 허용
+						.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
+								"/swagger-ui.html").permitAll()
 
-			// ✅ 기본 인증 방식 비활성화 (JWT 사용)
-			.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
-			.formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+						// MEMBER Domain
+						.requestMatchers(POST, "/api/v1/member/signup").permitAll()
+						.requestMatchers(POST, "/api/v1/member/signin").permitAll()
 
-			// ✅ 예외 처리 설정
-			.exceptionHandling(exceptionHandling -> exceptionHandling
-				.authenticationEntryPoint(authenticationEntryPoint) // 인증이 수행되지 않았을 때 호출되는 핸들러
-				.accessDeniedHandler(accessDeniedHandler)); // 접근 권한이 없을 때 호출되는 핸들러
+						// Category Domain
+						.requestMatchers(GET, "/api/v1/category/**").permitAll()
+
+						// Comment Domain
+						// 해당 없음. 모두 인증 필요
+
+						// Community Domain
+						.requestMatchers(GET, "/api/v1/community/board").permitAll()
+						.requestMatchers(GET, "/api/v1/community/board/**").permitAll()
+
+						// Education / TechBook Domain
+						.requestMatchers(GET, "/api/v1/education/techbook/**").permitAll()
+						.requestMatchers(GET, "/api/v1/education/techbook").permitAll()
+
+						// Education / TechTube Domain
+						// 해당 없음. 모두 인증 필요
+
+						// Resume Domain
+						.requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
+
+						// Project Domain
+						// 해당 없음. 모두 인증 필요
+
+						// Upload Domain
+						// 해당 없음. 모두 인증 필요
+
+						.anyRequest().authenticated()) // 그 외 요청은 인증 필요
+
+				// ✅ 기본 인증 방식 비활성화 (JWT 사용)
+				.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+				.formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+
+				// ✅ 예외 처리 설정
+				.exceptionHandling(exceptionHandling -> exceptionHandling
+						.authenticationEntryPoint(authenticationEntryPoint) // 인증이 수행되지 않았을 때 호출되는 핸들러
+						.accessDeniedHandler(accessDeniedHandler)); // 접근 권한이 없을 때 호출되는 핸들러
 
 		return http.build();
 	}
@@ -79,7 +110,7 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 허용할 오리진 설정
 		configuration.setAllowedOrigins(
-			List.of(frontendConfig.getFrontendUrl())); // 프론트 엔드
+				List.of(frontendConfig.getFrontendUrl())); // 프론트 엔드
 		// 허용할 HTTP 메서드 설정
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 프론트 엔드 허용 메서드
 		// 자격 증명 허용 설정
@@ -88,7 +119,7 @@ public class SecurityConfig {
 		configuration.setAllowedHeaders(Collections.singletonList("*"));
 
 		configuration.setExposedHeaders(
-			List.of("Set-Cookie"));
+				List.of("Set-Cookie"));
 
 		// CORS 설정을 소스에 등록
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/resources/config/prod/application-prod_auth.yml
+++ b/src/main/resources/config/prod/application-prod_auth.yml
@@ -41,3 +41,11 @@
 #            token-uri: https://nid.naver.com/oauth2.0/token
 #            user-info-uri: https://openapi.naver.com/v1/nid/me
 #            user-name-attribute: response.id
+custom:
+  jwt:
+    accessToken:
+      secret: ${JWT_ACCESS_TOKEN_SECRET}
+      expirationSeconds: "#{20 * 60}" # 20 minutes
+    refreshToken:
+      secret: ${JWT_REFRESH_TOKEN_SECRET}
+      expirationSeconds: "#{30 * 24 * 60 * 60}" # 30 days

--- a/src/main/resources/config/prod/application-prod_server.yml
+++ b/src/main/resources/config/prod/application-prod_server.yml
@@ -25,3 +25,6 @@ cloud:
       static: ${S3_REGION}
     s3:
       bucket: ${S3_BUCKET_NAME}
+
+frontend:
+  url: ${FRONTEND_URL}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#60 
  <br/>

## 🔎 작업 내용
- Security 인가 Path 설정 진행하였습니다. (`SecurityConfig`)
- `prod` 프로파일에서 누락된 설정 추가하였습니다. (`application-prod_db.yml`, `application-prod_auth.yml`)
- 로그인 된 회원의 ID 를 받아와야 하는 부분 (하드코딩 된 부분) 인증 받도록 변경하였습니다.
  - `@AuthenticationPrincipal CustomUser customUser`
  - `Comment`, `Community`, `FileUpload`, `Project`

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>