### PR TITLE
[FEAT] #PTDL-2 #PTD-1 프로젝트 상세 조회

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -1,7 +1,10 @@
 package ssammudan.cotree.domain.project.controller;
 
+import java.util.List;
+
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -13,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
@@ -42,14 +46,22 @@ public class ProjectController {
 	@Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
 	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
 	public BaseResponse<ProjectCreateResponse> createProject(
-			@RequestPart("request") @Valid ProjectCreateRequest request,
-			@RequestPart(value = "projectImage", required = false) MultipartFile projectImage,
-			@AuthenticationPrincipal CustomUser customUser
+		@RequestPart("request") @Valid ProjectCreateRequest request,
+		@RequestPart(value = "projectImage", required = false) MultipartFile projectImage,
+		@AuthenticationPrincipal CustomUser customUser
 	) {
 		String memberId = customUser.getId();
 		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, memberId);
 
 		return BaseResponse.success(SuccessCode.PROJECT_CREATE_SUCCESS, response);
+	}
+
+	@GetMapping("/hot")
+	@Operation(summary = "Hot 프로젝트 목록 조회", description = "Hot 프로젝트 2개 조회")
+	@ApiResponse(responseCode = "200", description = "Hot 프로젝트 조회 성공")
+	public BaseResponse<List<HotProjectResponse>> getHotProjects(
+	) {
+		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS, projectServiceImpl.getHotProjects());
 	}
 }
 

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -2,6 +2,8 @@ package ssammudan.cotree.domain.project.controller;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -15,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
@@ -51,5 +54,19 @@ public class ProjectController {
 
 		return BaseResponse.success(SuccessCode.PROJECT_CREATE_SUCCESS, response);
 	}
+
+	@GetMapping("/{projectId}")
+	@Operation(summary = "프로젝트 상세 조회", description = "특정 프로젝트의 상세 정보를 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	public BaseResponse<ProjectInfoResponse> getProjectInfo(
+		@PathVariable Long projectId,
+		@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = (customUser != null) ? customUser.getId() : null;
+		ProjectInfoResponse response = projectServiceImpl.getProjectInfo(projectId, memberId);
+
+		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS, response);
+	}
+
 }
 

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -34,6 +34,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     sangxxjin               Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 @RestController
 @RequestMapping("/api/v1/project/team")

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -1,10 +1,7 @@
 package ssammudan.cotree.domain.project.controller;
 
-import java.util.List;
-
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -16,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
@@ -34,7 +30,6 @@ import ssammudan.cotree.global.response.SuccessCode;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     sangxxjin               Initial creation
- * 2025-04-02    sangxxjin             get HotProject
  */
 @RestController
 @RequestMapping("/api/v1/project/team")
@@ -55,14 +50,6 @@ public class ProjectController {
 		ProjectCreateResponse response = projectServiceImpl.create(request, projectImage, memberId);
 
 		return BaseResponse.success(SuccessCode.PROJECT_CREATE_SUCCESS, response);
-	}
-
-	@GetMapping("/hot")
-	@Operation(summary = "Hot 프로젝트 목록 조회", description = "Hot 프로젝트 2개 조회")
-	@ApiResponse(responseCode = "200", description = "Hot 프로젝트 조회 성공")
-	public BaseResponse<List<HotProjectResponse>> getHotProjects(
-	) {
-		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS, projectServiceImpl.getHotProjects());
 	}
 }
 

--- a/src/main/java/ssammudan/cotree/domain/project/dto/HotProjectResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/HotProjectResponse.java
@@ -1,0 +1,56 @@
+package ssammudan.cotree.domain.project.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.project.project.entity.Project;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : HotProjectResponse
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 3.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 3.     sangxxjin               Initial creation
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public record HotProjectResponse(
+	Long id,
+	String title,
+	String description,
+	String imageUrl,
+	int viewCount,
+	long likeCount,
+	int recruitmentCount,
+	LocalDate startDate,
+	LocalDate endDate,
+	List<String> techStacksImageUrl,
+	String username,
+	String userProfileImageUrl
+) {
+	public static HotProjectResponse from(Project project, List<String> techStacksImageUrl, long likeCount,
+		Member member,
+		int recruitmentCount) {
+		return HotProjectResponse.builder()
+			.id(project.getId())
+			.title(project.getTitle())
+			.description(project.getDescription().length() > 30 ? project.getDescription().substring(0, 30) + "..." :
+				project.getDescription())
+			.imageUrl(project.getProjectImageUrl())
+			.viewCount(project.getViewCount())
+			.likeCount(likeCount)
+			.recruitmentCount(recruitmentCount)
+			.startDate(project.getStartDate())
+			.endDate(project.getEndDate())
+			.techStacksImageUrl(techStacksImageUrl)
+			.username(member.getUsername())
+			.userProfileImageUrl(member.getProfileImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/project/dto/HotProjectResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/HotProjectResponse.java
@@ -13,7 +13,7 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * FileName    : HotProjectResponse
  * Author      : sangxxjin
  * Date        : 2025. 4. 3.
- * Description : 
+ * Description : 핫한 프로젝트 조회 응답값
  * =====================================================================================================================
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectCreateRequest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.FutureOrPresent;
@@ -34,6 +35,10 @@ public record ProjectCreateRequest(
 	@NotBlank @Email String contact,
 	@NotBlank String partnerType,
 	@NotEmpty @Size(min = 1, max = 9) Set<Long> techStackIds,
+	@Schema(
+		description = "분야별 모집 인원 (Key: 분야 ID, Value: 모집 인원)",
+		example = "{\"1\": 3, \"2\": 5}"
+	)
 	@NotEmpty Map<Long, @NotNull @Min(1) @Max(10) Integer> recruitmentPositions,
 	@NotNull @PastOrPresent @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
 	@Nullable @FutureOrPresent @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectInfoResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectInfoResponse.java
@@ -1,0 +1,71 @@
+package ssammudan.cotree.domain.project.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.project.project.entity.Project;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : ProjectInfoResponse
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 3.
+ * Description : 프로젝트 상세조회 응답값
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 3.     sangxxjin               Initial creation
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public record ProjectInfoResponse(
+	String title,
+	String description,
+	String imageUrl,
+	String creatorName,
+	LocalDate startDate,
+	LocalDate endDate,
+	String contact,
+	List<Map<String, Integer>> devPositionsInfo,
+	List<String> techStacks,
+	String partnerType,
+	int viewCount,
+	long likeCount,
+	boolean isOpen,
+	boolean isLiked,
+	boolean isParticipant,
+	boolean isOwner
+) {
+	public static ProjectInfoResponse of(
+		Project project,
+		Member creator,
+		long likeCount,
+		List<Map<String, Integer>> devPositionsInfo,
+		List<String> techStacks,
+		boolean isLiked,
+		boolean isParticipant,
+		boolean isOwner
+	) {
+		return ProjectInfoResponse.builder()
+			.title(project.getTitle())
+			.description(project.getDescription())
+			.imageUrl(project.getProjectImageUrl())
+			.creatorName(creator.getUsername())
+			.startDate(project.getStartDate())
+			.endDate(project.getEndDate())
+			.contact(project.getContact())
+			.devPositionsInfo(devPositionsInfo)
+			.techStacks(techStacks)
+			.partnerType(project.getPartnerType())
+			.viewCount(project.getViewCount())
+			.likeCount(likeCount)
+			.isOpen(project.getIsOpen())
+			.isLiked(isLiked)
+			.isParticipant(isParticipant)
+			.isOwner(isOwner)
+			.build();
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 
 /**
  * PackageName : ssammudan.cotree.domain.project.service
@@ -25,4 +26,6 @@ public interface ProjectService {
 	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
 
 	List<HotProjectResponse> getHotProjects();
+
+	ProjectInfoResponse getProjectInfo(Long projectId, String memberId);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -1,7 +1,10 @@
 package ssammudan.cotree.domain.project.service;
 
+import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
+import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 
@@ -19,4 +22,6 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 
 public interface ProjectService {
 	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
+
+	List<HotProjectResponse> getHotProjects();
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -17,7 +17,8 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
  * =====================================================================================================================
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
- * 2025. 4. 2.     sangxxjin               Initial creation
+ * 2025-04-02.   sangxxjin             Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 
 public interface ProjectService {

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -1,6 +1,7 @@
 package ssammudan.cotree.domain.project.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.infra.s3.S3Directory;
@@ -25,6 +27,8 @@ import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.member.member.repository.MemberRepository;
 import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
 import ssammudan.cotree.model.project.devposition.repository.ProjectDevPositionRepository;
+import ssammudan.cotree.model.project.membership.repository.ProjectMembershipRepository;
+import ssammudan.cotree.model.project.membership.type.ProjectMembershipStatus;
 import ssammudan.cotree.model.project.project.entity.Project;
 import ssammudan.cotree.model.project.project.repository.ProjectRepository;
 import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
@@ -52,6 +56,7 @@ public class ProjectServiceImpl implements ProjectService {
 	private final ProjectDevPositionRepository projectDevPositionRepository;
 	private final S3Uploader s3Uploader;
 	private final LikeRepository likeRepository;
+	private final ProjectMembershipRepository projectMembershipRepository;
 
 	@Override
 	@Transactional
@@ -62,7 +67,7 @@ public class ProjectServiceImpl implements ProjectService {
 			.map(img -> s3Uploader.upload(memberId, img, S3Directory.PROJECT).getSaveUrl())
 			.orElse(null);
 
-		List<TechStack> techStacks = getTechStacks(request);
+		List<TechStack> techStacks = getTechStackNames(request);
 		List<DevelopmentPosition> devPositions = getDevelopmentPositions(request);
 
 		Member member = memberRepository.findById(memberId)
@@ -87,12 +92,49 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
+	public ProjectInfoResponse getProjectInfo(Long projectId, String memberId) {
+		Project project = projectRepository.findById(projectId)
+			.orElseThrow(() -> new GlobalException(ErrorCode.PROJECT_NOT_FOUND));
+
+		Member creator = project.getMember();
+
+		return ProjectInfoResponse.of(
+			project,
+			creator,
+			getLikeCount(projectId),
+			getDevPositionsInfo(projectId),
+			getTechStackNames(projectId),
+			isLikedByMember(projectId, memberId),
+			isMemberParticipant(projectId, memberId),
+			isProjectOwner(project, memberId)
+		);
+	}
+
+	@Transactional(readOnly = true)
 	public List<HotProjectResponse> getHotProjects() {
 		return projectRepository.findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc().stream()
 			.map(this::toHotProjectResponse)
 			.toList();
 	}
 
+	// 모집분야명, 인원수 조회
+	private List<Map<String, Integer>> getDevPositionsInfo(Long projectId) {
+		return projectDevPositionRepository.findByProjectId(projectId).stream()
+			.map(projectDevPosition -> Map.of(
+				projectDevPosition.getDevelopmentPosition().getName(),
+				projectDevPosition.getAmount()
+			))
+			.toList();
+	}
+
+	// 기술 스택 이름 조회
+	private List<String> getTechStackNames(Long projectId) {
+		return projectTechStackRepository.findByProjectId(projectId).stream()
+			.map(projectTechStack -> projectTechStack.getTechStack().getName())
+			.toList();
+	}
+
+	// Hot프로젝트 데이터가공
 	private HotProjectResponse toHotProjectResponse(Project project) {
 		List<String> techStackImageUrls = getTechStackImageUrls(project.getId());
 		long likeCount = likeRepository.countByProjectId(project.getId());
@@ -120,11 +162,34 @@ public class ProjectServiceImpl implements ProjectService {
 			.sum();
 	}
 
-	private List<TechStack> getTechStacks(ProjectCreateRequest request) {
+	private List<TechStack> getTechStackNames(ProjectCreateRequest request) {
 		return techStackRepository.findByIds(request.techStackIds());
 	}
 
 	private List<DevelopmentPosition> getDevelopmentPositions(ProjectCreateRequest request) {
 		return developmentPositionRepository.findByIds(request.recruitmentPositions().keySet());
+	}
+
+	// 좋아요 개수
+	private long getLikeCount(Long projectId) {
+		return likeRepository.countByProjectId(projectId);
+	}
+
+	// 좋아요 누른 멤버 확인
+	private boolean isLikedByMember(Long projectId, String memberId) {
+		return memberId != null && likeRepository.existsByProjectIdAndMemberId(projectId, memberId);
+	}
+
+	// 이미 참가한 프로젝트 여부 확인
+	private boolean isMemberParticipant(Long projectId, String memberId) {
+		return memberId != null &&
+			projectMembershipRepository.existsByProjectIdAndMemberIdAndProjectMembershipStatus(
+				projectId, memberId, ProjectMembershipStatus.JOINED
+			);
+	}
+
+	// 프로젝트 작성자 여부 확인
+	private boolean isProjectOwner(Project project, String memberId) {
+		return project.getMember().getId().equals(memberId);
 	}
 }

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
 
 				// Project Domain
 				.requestMatchers(GET, "/api/v1/project/team/hot").permitAll()
+				.requestMatchers(GET, "/api/v1/project/team/{projectId}").permitAll()
 
 				// Upload Domain
 				// 해당 없음. 모두 인증 필요

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -42,66 +42,66 @@ public class SecurityConfig {
 	SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 		http
-				// ✅ 보안 관련 설정 (CSRF, CORS, 세션)
-				.csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화 (JWT 사용 시 불필요)
-				.cors(cors -> corsConfigurationSource()) // CORS 설정 적용
-				.sessionManagement(
-						session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 방식)
+			// ✅ 보안 관련 설정 (CSRF, CORS, 세션)
+			.csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화 (JWT 사용 시 불필요)
+			.cors(cors -> corsConfigurationSource()) // CORS 설정 적용
+			.sessionManagement(
+				session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 방식)
 
-				// ✅ 필터 설정 (JWT 인증 필터 → UsernamePasswordAuthenticationFilter)
-				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+			// ✅ 필터 설정 (JWT 인증 필터 → UsernamePasswordAuthenticationFilter)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
-				// ✅ 인증 및 접근 권한 설정
-				.authorizeHttpRequests(authorize -> authorize
-						// H2 콘솔 허용
-						.requestMatchers("/h2-console/**").permitAll()
-						// 프론트엔드에서 적용될 예외 포인트 설정
-						.requestMatchers("/error", "/favicon.ico").permitAll()
-						// Swagger 문서 접근 허용
-						.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-								"/swagger-ui.html").permitAll()
-						.requestMatchers(GET, "/actuator/health").permitAll()
+			// ✅ 인증 및 접근 권한 설정
+			.authorizeHttpRequests(authorize -> authorize
+				// H2 콘솔 허용
+				.requestMatchers("/h2-console/**").permitAll()
+				// 프론트엔드에서 적용될 예외 포인트 설정
+				.requestMatchers("/error", "/favicon.ico").permitAll()
+				// Swagger 문서 접근 허용
+				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
+					"/swagger-ui.html").permitAll()
+				.requestMatchers(GET, "/actuator/health").permitAll()
 
-						// MEMBER Domain
-						.requestMatchers(POST, "/api/v1/member/signup").permitAll()
-						.requestMatchers(POST, "/api/v1/member/signin").permitAll()
+				// MEMBER Domain
+				.requestMatchers(POST, "/api/v1/member/signup").permitAll()
+				.requestMatchers(POST, "/api/v1/member/signin").permitAll()
 
-						// Category Domain
-						.requestMatchers(GET, "/api/v1/category/**").permitAll()
+				// Category Domain
+				.requestMatchers(GET, "/api/v1/category/**").permitAll()
 
-						// Comment Domain
-						// 해당 없음. 모두 인증 필요
+				// Comment Domain
+				// 해당 없음. 모두 인증 필요
 
-						// Community Domain
-						.requestMatchers(GET, "/api/v1/community/board").permitAll()
-						.requestMatchers(GET, "/api/v1/community/board/**").permitAll()
+				// Community Domain
+				.requestMatchers(GET, "/api/v1/community/board").permitAll()
+				.requestMatchers(GET, "/api/v1/community/board/**").permitAll()
 
-						// Education / TechBook Domain
-						.requestMatchers(GET, "/api/v1/education/techbook/**").permitAll()
-						.requestMatchers(GET, "/api/v1/education/techbook").permitAll()
+				// Education / TechBook Domain
+				.requestMatchers(GET, "/api/v1/education/techbook/**").permitAll()
+				.requestMatchers(GET, "/api/v1/education/techbook").permitAll()
 
-						// Education / TechTube Domain
-						// 해당 없음. 모두 인증 필요
+				// Education / TechTube Domain
+				// 해당 없음. 모두 인증 필요
 
-						// Resume Domain
-						// .requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
+				// Resume Domain
+				// .requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
 
-						// Project Domain
-						// 해당 없음. 모두 인증 필요
+				// Project Domain
+				.requestMatchers(GET, "/api/v1/project/team/hot").permitAll()
 
-						// Upload Domain
-						// 해당 없음. 모두 인증 필요
+				// Upload Domain
+				// 해당 없음. 모두 인증 필요
 
-						.anyRequest().authenticated()) // 그 외 요청은 인증 필요
+				.anyRequest().authenticated()) // 그 외 요청은 인증 필요
 
-				// ✅ 기본 인증 방식 비활성화 (JWT 사용)
-				.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
-				.formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
+			// ✅ 기본 인증 방식 비활성화 (JWT 사용)
+			.httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+			.formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
 
-				// ✅ 예외 처리 설정
-				.exceptionHandling(exceptionHandling -> exceptionHandling
-						.authenticationEntryPoint(authenticationEntryPoint) // 인증이 수행되지 않았을 때 호출되는 핸들러
-						.accessDeniedHandler(accessDeniedHandler)); // 접근 권한이 없을 때 호출되는 핸들러
+			// ✅ 예외 처리 설정
+			.exceptionHandling(exceptionHandling -> exceptionHandling
+				.authenticationEntryPoint(authenticationEntryPoint) // 인증이 수행되지 않았을 때 호출되는 핸들러
+				.accessDeniedHandler(accessDeniedHandler)); // 접근 권한이 없을 때 호출되는 핸들러
 
 		return http.build();
 	}
@@ -111,7 +111,7 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 허용할 오리진 설정
 		configuration.setAllowedOrigins(
-				List.of(frontendConfig.getFrontendUrl())); // 프론트 엔드
+			List.of(frontendConfig.getFrontendUrl())); // 프론트 엔드
 		// 허용할 HTTP 메서드 설정
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 프론트 엔드 허용 메서드
 		// 자격 증명 허용 설정
@@ -120,7 +120,7 @@ public class SecurityConfig {
 		configuration.setAllowedHeaders(Collections.singletonList("*"));
 
 		configuration.setExposedHeaders(
-				List.of("Set-Cookie"));
+			List.of("Set-Cookie"));
 
 		// CORS 설정을 소스에 등록
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
 	NOT_FOUND_RESUME(HttpStatus.NOT_FOUND, "3001", "해당하는 이력서를 찾을 수 없습니다"),
 
 	//Project: 4001 ~ 5000
-
+	PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "4001", "해당하는 프로젝트를 찾을 수 없습니다."),
+	
 	//Community: 5001 ~ 6000
 	COMMUNITY_BOARD_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "5001", "유효하지 않은 글 카테고리 입니다."),
 	COMMUNITY_MEMBER_NOTFOUND(HttpStatus.BAD_REQUEST, "5002", "존재하지 않은 회원입니다."),

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -27,6 +27,7 @@ public enum SuccessCode {
 
 	//Project
 	PROJECT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "프로젝트 생성 성공"),
+	PROJECT_HOT_LIST_SEARCH_SUCCESS(HttpStatus.OK, "200", "Hot 프로젝트 조회 성공"),
 
 	//Community
 	COMMUNITY_BOARD_CREATE_SUCCESS(HttpStatus.CREATED, "201", "글 작성 성공"),

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -28,6 +28,7 @@ public enum SuccessCode {
 	//Project
 	PROJECT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "프로젝트 생성 성공"),
 	PROJECT_HOT_LIST_SEARCH_SUCCESS(HttpStatus.OK, "200", "Hot 프로젝트 조회 성공"),
+	PROJECT_FETCH_SUCCESS(HttpStatus.OK, "200", "프로젝트 상세 조회 성공"),
 
 	//Community
 	COMMUNITY_BOARD_CREATE_SUCCESS(HttpStatus.CREATED, "201", "글 작성 성공"),

--- a/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
+++ b/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
@@ -18,4 +18,6 @@ import ssammudan.cotree.model.common.like.entity.Like;
  */
 public interface LikeRepository extends JpaRepository<Like, Long> {
 	long countByProjectId(Long id);
+
+	boolean existsByProjectIdAndMemberId(Long projectId, String memberId);
 }

--- a/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
+++ b/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
@@ -14,6 +14,7 @@ import ssammudan.cotree.model.common.like.entity.Like;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 public interface LikeRepository extends JpaRepository<Like, Long> {
 	long countByProjectId(Long id);

--- a/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
+++ b/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepository.java
@@ -16,4 +16,5 @@ import ssammudan.cotree.model.common.like.entity.Like;
  * 2025-03-29     Baekgwa               Initial creation
  */
 public interface LikeRepository extends JpaRepository<Like, Long> {
+	long countByProjectId(Long id);
 }

--- a/src/main/java/ssammudan/cotree/model/project/devposition/repository/ProjectDevPositionRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/devposition/repository/ProjectDevPositionRepository.java
@@ -16,6 +16,7 @@ import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 public interface ProjectDevPositionRepository extends JpaRepository<ProjectDevPosition, Long> {
 	List<ProjectDevPosition> findByProjectId(Long id);

--- a/src/main/java/ssammudan/cotree/model/project/devposition/repository/ProjectDevPositionRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/devposition/repository/ProjectDevPositionRepository.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.model.project.devposition.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
@@ -16,4 +18,5 @@ import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
  * 2025-03-29     Baekgwa               Initial creation
  */
 public interface ProjectDevPositionRepository extends JpaRepository<ProjectDevPosition, Long> {
+	List<ProjectDevPosition> findByProjectId(Long id);
 }

--- a/src/main/java/ssammudan/cotree/model/project/membership/entity/ProjectMembership.java
+++ b/src/main/java/ssammudan/cotree/model/project/membership/entity/ProjectMembership.java
@@ -13,8 +13,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import ssammudan.cotree.global.entity.BaseEntity;
-import ssammudan.cotree.model.project.project.entity.Project;
+import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.project.membership.type.ProjectMembershipStatus;
+import ssammudan.cotree.model.project.project.entity.Project;
 
 /**
  * PackageName : ssammudan.cotree.model.project.membership.entity
@@ -26,6 +27,7 @@ import ssammudan.cotree.model.project.membership.type.ProjectMembershipStatus;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04-03     sangxxjin             빠져있던 member 컬럼 추가
  */
 @Entity
 @Getter
@@ -36,6 +38,10 @@ public class ProjectMembership extends BaseEntity {
 	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "project_id", nullable = false)

--- a/src/main/java/ssammudan/cotree/model/project/membership/repository/ProjectMembershipRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/membership/repository/ProjectMembershipRepository.java
@@ -3,6 +3,7 @@ package ssammudan.cotree.model.project.membership.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.membership.entity.ProjectMembership;
+import ssammudan.cotree.model.project.membership.type.ProjectMembershipStatus;
 
 /**
  * PackageName : ssammudan.cotree.model.project.membership.repository
@@ -16,4 +17,6 @@ import ssammudan.cotree.model.project.membership.entity.ProjectMembership;
  * 2025-03-29     Baekgwa               Initial creation
  */
 public interface ProjectMembershipRepository extends JpaRepository<ProjectMembership, Long> {
+	boolean existsByProjectIdAndMemberIdAndProjectMembershipStatus(Long projectId, String memberId,
+		ProjectMembershipStatus projectMembershipStatus);
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
@@ -16,6 +16,7 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 	List<Project> findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc();

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.model.project.project.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.project.entity.Project;
@@ -16,4 +18,5 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * 2025-03-29     Baekgwa               Initial creation
  */
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+	List<Project> findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc();
 }

--- a/src/main/java/ssammudan/cotree/model/project/techstack/repository/ProjectTechStackRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/techstack/repository/ProjectTechStackRepository.java
@@ -16,6 +16,7 @@ import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
+ * 2025-04-02    sangxxjin             get HotProject
  */
 public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
 	List<ProjectTechStack> findByProjectId(Long id);

--- a/src/main/java/ssammudan/cotree/model/project/techstack/repository/ProjectTechStackRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/techstack/repository/ProjectTechStackRepository.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.model.project.techstack.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
@@ -16,4 +18,5 @@ import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
  * 2025-03-29     Baekgwa               Initial creation
  */
 public interface ProjectTechStackRepository extends JpaRepository<ProjectTechStack, Long> {
+	List<ProjectTechStack> findByProjectId(Long id);
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->
## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

<br/>

## #️⃣연관된 이슈
#71 #73  
<br/>

## 🔎 작업 내용
- 특정 프로젝트의 상세 정보를 조회할 수 있도록 기능 구현
- 프로젝트의 주요 정보(제목, 내용, 사진, 생성자 이름, 시작일, 마감일, 연락처 등) 반환
- 모집 분야, 기술 스택, 인재상, 좋아요 개수, 조회수, 모집 여부 추가
- 프로젝트 생성자 여부 확인 기능 추가
- 프로젝트 참가 여부 확인 기능 추가 (JOINED 상태만 해당)
- 사용자가 좋아요를 눌렀는지 여부 확인 기능 추가

- 프로젝트 생성 api 스웨거 문서 가독성 향상을 위해 스키마 적용
- 하나의 api로 로그인 여부 상관없이 조회 가능하게 구현
<br/>

## 💬 집중 리뷰 요구
- `isParticipant`, `isOwner`, `isLiked` 로직의 가독성 및 효율성 검토 필요합니다.
- 조회 로직 개선 사항 있으면 부탁드립니다! 

<br/>

## 📈이미지 첨부 (필요시)
![image](https://github.com/user-attachments/assets/386dc366-ddf9-41e8-98fb-85b21154fea0)

  <br/>