### PR TITLE
[FEAT] : #CBDC-2, #RRDC-2 댓글 조회 기능 구현

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/controller/CommentController.java
@@ -1,9 +1,13 @@
 package ssammudan.cotree.domain.comment.controller;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,9 +15,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.comment.dto.CommentRequest;
+import ssammudan.cotree.domain.comment.dto.CommentResponse;
 import ssammudan.cotree.domain.comment.service.CommentService;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
 /**
@@ -21,7 +28,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * FileName    : CommentController
  * Author      : Baekgwa
  * Date        : 2025-04-02
- * Description : 
+ * Description :
  * =====================================================================================================================
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
@@ -43,5 +50,22 @@ public class CommentController {
 		String memberId = customUser.getId();
 		commentService.postNewComment(postComment, memberId);
 		return BaseResponse.success(SuccessCode.COMMENT_CREATE_SUCCESS);
+	}
+
+	@GetMapping
+	@Operation(summary = "댓글/대댓글 조회")
+	public BaseResponse<PageResponse<CommentResponse.CommentInfo>> postNewComment(
+			@RequestParam(value = "itemId") Long itemId,
+			@RequestParam(value = "category") CommentCategory category,
+			@RequestParam(value = "page", defaultValue = "0", required = false) int page,
+			@RequestParam(value = "size", defaultValue = "5", required = false) int size,
+			@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = (customUser != null) ? customUser.getId() : null;
+		Pageable pageable = PageRequest.of(page, size);
+
+		PageResponse<CommentResponse.CommentInfo> commentList =
+				commentService.getCommentList(pageable, memberId, category, itemId);
+		return BaseResponse.success(SuccessCode.COMMENT_SEARCH_SUCCESS, commentList);
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/dto/CommentResponse.java
@@ -26,7 +26,7 @@ public class CommentResponse {
 	}
 
 	@Getter
-	@Builder
+	@Builder(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class CommentInfo {
 		private final Long id;
@@ -52,7 +52,7 @@ public class CommentResponse {
 	}
 
 	@Getter
-	@Builder
+	@Builder(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class ChildCommentInfo {
 		private final Long id;

--- a/src/main/java/ssammudan/cotree/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,77 @@
+package ssammudan.cotree.domain.comment.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ssammudan.cotree.model.common.comment.repository.CommentInfoProjection;
+
+/**
+ * PackageName : ssammudan.cotree.domain.comment.dto
+ * FileName    : CommentResponse
+ * Author      : Baekgwa
+ * Date        : 2025-04-03
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-03     Baekgwa               Initial creation
+ */
+public class CommentResponse {
+
+	private CommentResponse() {
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class CommentInfo {
+		private final Long id;
+		private final String profileImageUrl;
+		private final String author;
+		private final LocalDateTime createdAt;
+		private final String content;
+		private final Boolean isAuthor;
+		private final List<ChildCommentInfo> subComment;
+
+		public static CommentInfo from(CommentInfoProjection commentInfo, List<ChildCommentInfo> subComment) {
+			return CommentInfo
+					.builder()
+					.id(commentInfo.getId())
+					.profileImageUrl(commentInfo.getProfileImageUrl())
+					.author(commentInfo.getAuthor())
+					.createdAt(commentInfo.getCreatedAt())
+					.content(commentInfo.getContent())
+					.isAuthor(commentInfo.getIsAuthor())
+					.subComment(subComment)
+					.build();
+		}
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class ChildCommentInfo {
+		private final Long id;
+		private final String profileImageUrl;
+		private final String author;
+		private final LocalDateTime createdAt;
+		private final String content;
+		private final Boolean isAuthor;
+
+		public static ChildCommentInfo of(CommentInfoProjection commentInfoProjection) {
+			return ChildCommentInfo
+					.builder()
+					.id(commentInfoProjection.getId())
+					.profileImageUrl(commentInfoProjection.getProfileImageUrl())
+					.author(commentInfoProjection.getAuthor())
+					.createdAt(commentInfoProjection.getCreatedAt())
+					.content(commentInfoProjection.getContent())
+					.isAuthor(commentInfoProjection.getIsAuthor())
+					.build();
+		}
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/comment/service/CommentService.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/service/CommentService.java
@@ -1,6 +1,11 @@
 package ssammudan.cotree.domain.comment.service;
 
+import org.springframework.data.domain.Pageable;
+
 import ssammudan.cotree.domain.comment.dto.CommentRequest;
+import ssammudan.cotree.domain.comment.dto.CommentResponse;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
+import ssammudan.cotree.global.response.PageResponse;
 
 /**
  * PackageName : ssammudan.cotree.domain.comment.service
@@ -15,5 +20,9 @@ import ssammudan.cotree.domain.comment.dto.CommentRequest;
  */
 public interface CommentService {
 
-	void postNewComment(final CommentRequest.PostComment postComment, final String memberId);
+	void postNewComment(
+			final CommentRequest.PostComment postComment, final String memberId);
+
+	PageResponse<CommentResponse.CommentInfo> getCommentList(
+			final Pageable pageable, final String memberId, final CommentCategory category, final Long itemId);
 }

--- a/src/main/java/ssammudan/cotree/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/comment/service/CommentServiceImpl.java
@@ -1,12 +1,17 @@
 package ssammudan.cotree.domain.comment.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.comment.dto.CommentRequest;
+import ssammudan.cotree.domain.comment.dto.CommentResponse;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.model.common.comment.entity.Comment;
 import ssammudan.cotree.model.common.comment.repository.CommentRepository;
 import ssammudan.cotree.model.community.community.entity.Community;
@@ -49,6 +54,18 @@ public class CommentServiceImpl implements CommentService {
 		Comment newComment = createCommentByCategory(postComment, commentAuthor, parentComment);
 
 		commentRepository.save(newComment);
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public PageResponse<CommentResponse.CommentInfo> getCommentList(
+			final Pageable pageable,
+			final String memberId,
+			final CommentCategory category,
+			final Long itemId) {
+		Page<CommentResponse.CommentInfo> commentList =
+				commentRepository.findCommentList(pageable, memberId, category, itemId);
+		return PageResponse.of(commentList);
 	}
 
 	private Member findCommentAuthor(String memberId) {

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
 						.requestMatchers(GET, "/api/v1/category/**").permitAll()
 
 						// Comment Domain
-						// 해당 없음. 모두 인증 필요
+						.requestMatchers(GET, "/api/v1/comment/**").permitAll()
 
 						// Community Domain
 						.requestMatchers(GET, "/api/v1/community/board").permitAll()

--- a/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
 	POST_COMMENT_FAIL_RESUME_NOTFOUND(HttpStatus.BAD_REQUEST, "7002", "커뮤니티 댓글 작성 실패. 잘못된 글 ID 입니다."),
 	POST_COMMENT_FAIL_PARENT_COMMENT_NOTFOUND(HttpStatus.BAD_REQUEST, "7003", "대댓글 작성 실패. 잘못된 댓글 ID 입니다."),
 	POST_COMMENT_FAIL_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "7004", "댓글 작성 실패. 잘못된 카테고리 입니다."),
+	COMMENT_GET_FAIL_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "7005", "댓글 조회 실패. 잘못된 카테고리 입니다."),
 
 	//${}: 8001 ~ 9000
 

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -38,6 +38,7 @@ public enum SuccessCode {
 
 	//Comment:
 	COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "댓글 작성 성공"),
+	COMMENT_SEARCH_SUCCESS(HttpStatus.OK, "200", "댓글 목록 조회 성공"),
 
 	//${}: 8001 ~ 9000
 

--- a/src/main/java/ssammudan/cotree/model/common/comment/entity/Comment.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/entity/Comment.java
@@ -59,7 +59,7 @@ public class Comment extends BaseEntity {
 	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
 	private String content;
 
-	@Builder
+	@Builder(access = AccessLevel.PRIVATE)
 	private Comment(Comment parentComment, Member author, Community community, Resume resume, String content) {
 		this.parentComment = parentComment;
 		this.author = author;

--- a/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentInfoProjection.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentInfoProjection.java
@@ -1,0 +1,47 @@
+package ssammudan.cotree.model.common.comment.repository;
+
+import java.time.LocalDateTime;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+
+/**
+ * PackageName : ssammudan.cotree.model.common.comment.repository
+ * FileName    : ChildCommentInfo
+ * Author      : Baekgwa
+ * Date        : 2025-04-03
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-03     Baekgwa               Initial creation
+ */
+@Getter
+public class CommentInfoProjection {
+	private final Long id;
+	private final Long parentId;
+	private final String profileImageUrl;
+	private final String author;
+	private final LocalDateTime createdAt;
+	private final String content;
+	private final Boolean isAuthor;
+
+	@QueryProjection
+	public CommentInfoProjection(
+			Long id,
+			Long parentId,
+			String profileImageUrl,
+			String author,
+			LocalDateTime createdAt,
+			String content,
+			Boolean isAuthor) {
+		this.id = id;
+		this.parentId = parentId;
+		this.profileImageUrl = profileImageUrl;
+		this.author = author;
+		this.createdAt = createdAt;
+		this.content = content;
+		this.isAuthor = isAuthor;
+	}
+}

--- a/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepository.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepository.java
@@ -15,5 +15,5 @@ import ssammudan.cotree.model.common.comment.entity.Comment;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-29     Baekgwa               Initial creation
  */
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 }

--- a/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,26 @@
+package ssammudan.cotree.model.common.comment.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.domain.comment.dto.CommentResponse;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
+
+/**
+ * PackageName : ssammudan.cotree.model.common.comment.repository
+ * FileName    : CommentRepositoryCustom
+ * Author      : Baekgwa
+ * Date        : 2025-04-03
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-03     Baekgwa               Initial creation
+ */
+public interface CommentRepositoryCustom {
+	Page<CommentResponse.CommentInfo> findCommentList(
+			final Pageable pageable,
+			final String memberId,
+			final CommentCategory category,
+			final Long itemId);
+}

--- a/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/common/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,146 @@
+package ssammudan.cotree.model.common.comment.repository;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.comment.dto.CommentResponse;
+import ssammudan.cotree.domain.comment.type.CommentCategory;
+import ssammudan.cotree.model.common.comment.entity.QComment;
+import ssammudan.cotree.model.member.member.entity.QMember;
+
+/**
+ * PackageName : ssammudan.cotree.model.common.comment.repository
+ * FileName    : CommentRepositoryImpl
+ * Author      : Baekgwa
+ * Date        : 2025-04-03
+ * Description :
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-03     Baekgwa               Initial creation
+ */
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private static final QComment comment = QComment.comment;
+	private static final QMember member = QMember.member;
+
+	@Override
+	public Page<CommentResponse.CommentInfo> findCommentList(
+			final Pageable pageable,
+			final String memberId,
+			final CommentCategory category,
+			final Long itemId) {
+
+		// 부모 댓글 조회용 where 조건 생성
+		BooleanExpression whereCondition = createWhereCondition(category, itemId);
+
+		// 부모 댓글 ID 조회 (페이징 적용)
+		List<Long> parentCommentIdList = findParentCommentIdList(pageable, whereCondition);
+
+		// 만약 부모 ID 들이 비어있다면, 바로 조회 결과 없음
+		if (parentCommentIdList.isEmpty()) {
+			return new PageImpl<>(List.of(), pageable, 0);
+		}
+
+		// 부모 댓글 및 대댓글 전체 조회
+		List<CommentInfoProjection> allComment = findAllComment(parentCommentIdList, memberId);
+
+		// 댓글 / 대댓글 정리
+		List<CommentResponse.CommentInfo> response = buildCommentInfo(allComment);
+
+		// 부모 댓글 개수 조회
+		long total = countParentComment(whereCondition);
+
+		return new PageImpl<>(response, pageable, total);
+	}
+
+	private BooleanExpression createWhereCondition(CommentCategory category, Long itemId) {
+		return switch (category) {
+			case COMMUNITY -> comment.parentComment.id.isNull().and(comment.community.id.eq(itemId));
+			case RESUME -> comment.parentComment.id.isNull().and(comment.resume.id.eq(itemId));
+		};
+	}
+
+	private List<Long> findParentCommentIdList(Pageable pageable, BooleanExpression whereCondition) {
+		return jpaQueryFactory
+				.select(comment.id)
+				.from(comment)
+				.where(whereCondition)
+				.orderBy(comment.createdAt.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
+	}
+
+	private List<CommentInfoProjection> findAllComment(List<Long> parentCommentIds, String memberId) {
+		return jpaQueryFactory
+				.select(new QCommentInfoProjection(
+						comment.id,
+						comment.parentComment.id,
+						member.profileImageUrl,
+						member.nickname,
+						comment.createdAt,
+						comment.content,
+						memberId != null ? (member.id.eq(memberId))
+								: (Expressions.constant(Boolean.FALSE))
+				))
+				.from(comment)
+				.join(member).on(comment.author.id.eq(member.id))
+				.where(comment.id.in(parentCommentIds)
+						.or(comment.parentComment.id.in(parentCommentIds)))
+				.orderBy(comment.createdAt.desc())
+				.fetch();
+	}
+
+	private long countParentComment(BooleanExpression whereCondition) {
+		return Optional.ofNullable(
+				jpaQueryFactory
+						.select(comment.count())
+						.from(comment)
+						.where(whereCondition)
+						.fetchOne()
+		).orElse(0L);
+	}
+
+	private List<CommentResponse.CommentInfo> buildCommentInfo(List<CommentInfoProjection> allCommentList) {
+		// 대댓글을 부모 ID 기준으로 그룹화
+		Map<Long, List<CommentResponse.ChildCommentInfo>> subCommentMap = allCommentList.stream()
+				.filter(c -> c.getParentId() != null)
+				.collect(Collectors.groupingBy(
+						CommentInfoProjection::getParentId,
+						Collectors.mapping(CommentResponse.ChildCommentInfo::of, Collectors.toList())
+				));
+
+		// 부모 댓글 리스트 생성
+		List<CommentInfoProjection> parentCommentList = allCommentList.stream()
+				.filter(c -> c.getParentId() == null)
+				.toList();
+
+		// 대댓글 최신순 정렬
+		subCommentMap.forEach((parentId, subComments) ->
+				subComments.sort(Comparator.comparing(CommentResponse.ChildCommentInfo::getCreatedAt).reversed())
+		);
+
+		// 최종 결과 빌드 & 리턴
+		return parentCommentList.stream()
+				.map(parent -> CommentResponse.CommentInfo.from(parent,
+						subCommentMap.getOrDefault(parent.getId(), List.of())))
+				.toList();
+	}
+}

--- a/src/main/java/ssammudan/cotree/model/community/category/entity/CommunityCategory.java
+++ b/src/main/java/ssammudan/cotree/model/community/category/entity/CommunityCategory.java
@@ -35,7 +35,7 @@ public class CommunityCategory {
 	@Column(name = "name", nullable = false, unique = true)
 	private String name;
 
-	@Builder
+	@Builder(access = AccessLevel.PRIVATE)
 	private CommunityCategory(String name) {
 		this.name = name;
 	}

--- a/src/main/java/ssammudan/cotree/model/community/community/entity/Community.java
+++ b/src/main/java/ssammudan/cotree/model/community/community/entity/Community.java
@@ -56,7 +56,7 @@ public class Community extends BaseEntity {
 	@Column(name = "view_count", nullable = false)
 	private Integer viewCount;
 
-	@Builder
+	@Builder(access = AccessLevel.PRIVATE)
 	private Community(CommunityCategory communityCategory, Member member, String title, String content,
 			Integer viewCount) {
 		this.communityCategory = communityCategory;


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#54 
  <br/>

## 🔎 작업 내용
- 이력서와 커뮤니티 글의 댓글을 조회하는 기능을 구현하였습니다.
- 통합으로 진행하였습니다.
- QueryDSL 을 활용하였습니다.
- 테스트 코드는 추후 작성 예정이며, 로컬 환경 수동 테스트는 진행 완료하였습니다.
- 댓글과 대댓글이 존재하며, 댓글은 페이지네이션 적용, 대댓글은 전체 조회로 구성하였습니다.
- 내부 로직은 최적화를 위해, 다음 플로우를 적용하였습니다.
  - (itemId 로 댓글 size 만큼 가져오기) -> (가져온 댓글 id 들을 활용해, 대댓글과 댓글 정보 전체 find) -> (parent_id 유무로 댓글/대댓글 정리 및 sorting) -> 응답


  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- 생각하고 보니, 댓글/대댓글 정리하고 sorting 하는 작업이 queryDSL 이 있는 repository 레이어에서 진행되었는데, 생각하고 보니 service 레이어로 옮기는게 좋은 것 같습니다. 해당 의견 검토 부탁드립니다!

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>