### PR TITLE
[BUG] TechBook, 리뷰(수강평) 정렬 조건 누락 수정 등

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
@@ -1,8 +1,7 @@
 package ssammudan.cotree.domain.education.techbook.controller;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +15,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
 import ssammudan.cotree.domain.education.techbook.service.TechBookService;
+import ssammudan.cotree.domain.education.type.SearchEducationSort;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
@@ -53,9 +53,13 @@ public class TechBookController {
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	public BaseResponse<PageResponse<TechBookResponse.ListInfo>> getTechBooks(
 		@RequestParam(required = false) String keyword,
-		@PageableDefault(page = 0, size = 16, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+		@RequestParam(value = "page", required = false, defaultValue = "0") final int page,
+		@RequestParam(value = "size", required = false, defaultValue = "16") final int size,
+		@RequestParam(value = "sort", required = false, defaultValue = "LATEST") final SearchEducationSort sort
 	) {
-		PageResponse<TechBookResponse.ListInfo> responseDto = techBookService.findAllTechBooks(keyword, pageable);
+		PageResponse<TechBookResponse.ListInfo> responseDto = techBookService.findAllTechBooks(
+			keyword, PageRequest.of(page, size, Sort.Direction.DESC, sort.getValue())
+		);
 		return BaseResponse.success(SuccessCode.TECH_BOOK_LIST_FIND_SUCCESS, responseDto);
 	}
 

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
@@ -1,8 +1,11 @@
 package ssammudan.cotree.domain.education.techbook.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import ssammudan.cotree.model.education.category.entity.EducationCategory;
+import ssammudan.cotree.model.education.techbook.category.entity.TechBookEducationCategory;
 import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 
 /**
@@ -29,6 +32,8 @@ public class TechBookResponse {
 		String writer,                //TechBook 저자
 		@Schema(description = "TechBook 교육 난이도", example = "입문")
 		String educationLevel,        //TechBook 교육 난이도
+		@Schema(description = "TechBook 교육 카테고리", example = "백엔드")
+		List<String> educationCategories,
 		@Schema(description = "TechBook 제목", example = "Spring Boot")
 		String title,                 //TechBook 제목
 		@Schema(description = "TechBook 설명", example = "스프링 부트를 1000% 활용하는 방법!!")
@@ -61,6 +66,9 @@ public class TechBookResponse {
 				techBook.getId(),
 				techBook.getWriter().getNickname(),
 				techBook.getEducationLevel().getName(),
+				techBook.getTechBookEducationCategories().stream()
+					.map(TechBookEducationCategory::getEducationCategory)
+					.map(EducationCategory::getName).toList(),    //TODO: 성능 최적화 시 FETCH JOIN 활용 형태 적용 고려
 				techBook.getTitle(),
 				techBook.getDescription(),
 				techBook.getIntroduction(),

--- a/src/main/java/ssammudan/cotree/domain/education/type/SearchEducationSort.java
+++ b/src/main/java/ssammudan/cotree/domain/education/type/SearchEducationSort.java
@@ -1,0 +1,30 @@
+package ssammudan.cotree.domain.education.type;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * PackageName : ssammudan.cotree.domain.education.type
+ * FileName    : SearchEducationSort
+ * Author      : loadingKKamo21
+ * Date        : 25. 4. 4.
+ * Description : 교육 컨텐츠 정렬 조건 ENUM
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 4.     loadingKKamo21       Initial creation
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SearchEducationSort {
+
+	LATEST("createdAt"),
+	RATING("rating"),
+	LIKES("likeCount"),
+	VIEWS("viewCount"),
+	REVIEWS("reviewCount");
+
+	private final String value;
+
+}

--- a/src/main/java/ssammudan/cotree/domain/review/controller/TechEducationReviewController.java
+++ b/src/main/java/ssammudan/cotree/domain/review/controller/TechEducationReviewController.java
@@ -1,8 +1,7 @@
 package ssammudan.cotree.domain.review.controller;
 
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.review.dto.TechEducationReviewRequest;
 import ssammudan.cotree.domain.review.dto.TechEducationReviewResponse;
 import ssammudan.cotree.domain.review.service.TechEducationReviewService;
+import ssammudan.cotree.domain.review.type.SearchReviewSort;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.PageResponse;
@@ -62,10 +62,13 @@ public class TechEducationReviewController {
 	public BaseResponse<PageResponse<TechEducationReviewResponse.Detail>> getTechEducationReviews(
 		@RequestParam final TechEducationReviewType reviewType,
 		@RequestParam final Long itemId,
-		@PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+		@RequestParam(value = "page", required = false, defaultValue = "0") final int page,
+		@RequestParam(value = "size", required = false, defaultValue = "10") final int size,
+		@RequestParam(value = "sort", required = false, defaultValue = "LATEST") final SearchReviewSort sort
 	) {
 		PageResponse<TechEducationReviewResponse.Detail> responseDto = techEducationReviewService.findAllTechEducationReviews(
-			new TechEducationReviewRequest.Read(reviewType, itemId), pageable
+			new TechEducationReviewRequest.Read(reviewType, itemId),
+			PageRequest.of(page, size, Sort.Direction.DESC, sort.getValue())
 		);
 		return BaseResponse.success(SuccessCode.TECH_EDUCATION_REVIEW_LIST_FIND_SUCCESS, responseDto);
 	}

--- a/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
@@ -107,7 +107,7 @@ public class TechEducationReviewServiceImpl implements TechEducationReviewServic
 	public PageResponse<TechEducationReviewResponse.Detail> findAllTechEducationReviews(
 		final TechEducationReviewRequest.Read requestDto, final Pageable pageable
 	) {
-		return PageResponse.of(techEducationReviewRepository.findAllByTechEducationType_IdAndItemId(
+		return PageResponse.of(techEducationReviewRepository.findAllTechEducationReviews(
 			TechEducationReviewType.getTechEducationTypeId(
 				requestDto.techEducationType()), requestDto.itemId(), pageable
 		).map(TechEducationReviewResponse.Detail::from));

--- a/src/main/java/ssammudan/cotree/domain/review/type/SearchReviewSort.java
+++ b/src/main/java/ssammudan/cotree/domain/review/type/SearchReviewSort.java
@@ -1,0 +1,27 @@
+package ssammudan.cotree.domain.review.type;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * PackageName : ssammudan.cotree.domain.review.type
+ * FileName    : SearchReviewSort
+ * Author      : loadingKKamo21
+ * Date        : 25. 4. 4.
+ * Description : 교육 컨텐츠 리뷰 정렬 조건 ENUM
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 4.     loadingKKamo21       Initial creation
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SearchReviewSort {
+
+	LATEST("createdAt"),
+	RATING("rating");
+
+	private final String value;
+
+}

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
@@ -89,28 +89,28 @@ public class TechBookRepositoryImpl implements TechBookRepositoryCustom {
 	 */
 	private OrderSpecifier<?>[] getSortCondition(@NotNull final Pageable pageable, @NotNull final QTechBook techBook) {
 		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+		boolean hasCreatedAt = pageable.getSort().stream().anyMatch(order -> "createdAt".equals(order.getProperty()));
 
 		if (!pageable.getSort().isEmpty()) {
 			pageable.getSort().forEach(order -> {
 				Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
 
 				switch (order.getProperty()) {
-					case "title" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.title));
 					case "rating" -> orderSpecifiers.add(new OrderSpecifier(direction,
 						Expressions.numberTemplate(Double.class, "CASE WHEN {1} = 0 THEN 0 ELSE ({0} * 1.0 / {1}) END",
 							techBook.totalRating, techBook.totalReviewCount))
 					);
 					case "viewCount" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.viewCount));
-					case "totalReviewCount" ->
-						orderSpecifiers.add(new OrderSpecifier(direction, techBook.totalReviewCount));
+					case "reviewCount" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.totalReviewCount));
 					case "createdAt" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.createdAt));
+					case "likeCount" -> orderSpecifiers.add(new OrderSpecifier(direction, techBook.likes.size()));
 					default -> {
 					}
 				}
 			});
 		}
 
-		if (orderSpecifiers.isEmpty()) {
+		if (!hasCreatedAt) {
 			orderSpecifiers.add(new OrderSpecifier(Order.DESC, techBook.createdAt));
 		}
 

--- a/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepository.java
+++ b/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepository.java
@@ -2,8 +2,6 @@ package ssammudan.cotree.model.review.review.repository;
 
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.review.review.entity.TechEducationReview;
@@ -24,10 +22,6 @@ public interface TechEducationReviewRepository
 
 	Optional<TechEducationReview> findByReviewer_IdAndTechEducationType_IdAndItemId(
 		String reviewerId, Long techEducationTypeId, Long itemId
-	);
-
-	Page<TechEducationReview> findAllByTechEducationType_IdAndItemId(
-		Long techEducationTypeId, Long itemId, Pageable pageable
 	);
 
 }

--- a/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryCustom.java
@@ -1,5 +1,10 @@
 package ssammudan.cotree.model.review.review.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.model.review.review.entity.TechEducationReview;
+
 /**
  * PackageName : ssammudan.cotree.model.review.review.repository
  * FileName    : TechEducationReviewRepositoryCustom
@@ -12,4 +17,9 @@ package ssammudan.cotree.model.review.review.repository;
  * 25. 4. 1.     loadingKKamo21       Initial creation
  */
 public interface TechEducationReviewRepositoryCustom {
+
+	Page<TechEducationReview> findAllTechEducationReviews(
+		final Long techEducationTypeId, final Long itemId, final Pageable pageable
+	);
+
 }

--- a/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryImpl.java
@@ -1,10 +1,22 @@
 package ssammudan.cotree.model.review.review.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.model.review.review.entity.QTechEducationReview;
+import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 
 /**
  * PackageName : ssammudan.cotree.model.review.review.repository
@@ -22,5 +34,64 @@ import lombok.RequiredArgsConstructor;
 public class TechEducationReviewRepositoryImpl implements TechEducationReviewRepositoryCustom {
 
 	private final JPAQueryFactory jpaQueryFactory;
+
+	/**
+	 * TechEducationReview 페이징 목록 조회
+	 * @param techEducationTypeId - 교육 컨텐츠 타입 ID
+	 * @param itemId              - 교육 컨텐츠 ID
+	 * @param pageable            - 페이징 객체
+	 * @return Page<TechEducationReview>
+	 */
+	@Override
+	public Page<TechEducationReview> findAllTechEducationReviews(
+		final Long techEducationTypeId, final Long itemId, final Pageable pageable
+	) {
+		QTechEducationReview techEducationReview = QTechEducationReview.techEducationReview;
+		List<TechEducationReview> content = jpaQueryFactory.selectFrom(techEducationReview)
+			.where(techEducationReview.techEducationType.id.eq(techEducationTypeId),
+				techEducationReview.itemId.eq(itemId))
+			.orderBy(getSortCondition(pageable, techEducationReview))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+		JPAQuery<Long> count = jpaQueryFactory.select(techEducationReview.count())
+			.from(techEducationReview)
+			.where(techEducationReview.techEducationType.id.eq(techEducationTypeId),
+				techEducationReview.itemId.eq(itemId));
+		return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+	}
+
+	/**
+	 * 페이징 객체에 포함된 정렬 조건에 따라 OrderSpecifier[] 생성
+	 * @param pageable            - 페이징 객체
+	 * @param techEducationReview - Querydsl TechEducationReview
+	 * @return OrderSpecifier[]
+	 */
+	private OrderSpecifier<?>[] getSortCondition(
+		@NotNull final Pageable pageable, @NotNull final QTechEducationReview techEducationReview
+	) {
+		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+		boolean hasCreatedAt = pageable.getSort().stream().anyMatch(order -> "createdAt".equals(order.getProperty()));
+
+		if (!pageable.getSort().isEmpty()) {
+			pageable.getSort().forEach(order -> {
+				Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+				switch (order.getProperty()) {
+					case "rating" -> orderSpecifiers.add(new OrderSpecifier(direction, techEducationReview.rating));
+					case "createdAt" ->
+						orderSpecifiers.add(new OrderSpecifier(direction, techEducationReview.createdAt));
+					default -> {
+					}
+				}
+			});
+		}
+
+		if (!hasCreatedAt) {
+			orderSpecifiers.add(new OrderSpecifier(Order.DESC, techEducationReview.createdAt));
+		}
+
+		return orderSpecifiers.toArray(new OrderSpecifier[0]);
+	}
 
 }

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/controller/TechBookControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/controller/TechBookControllerTest.java
@@ -138,7 +138,7 @@ class TechBookControllerTest extends WebMvcTestSupporter {
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("page", "0");
 		params.add("size", "16");
-		params.add("sort", "createdAt,DESC");
+		params.add("sort", "LATEST");
 		params.add("keyword", dtoFixtureMonkey.giveMeOne(String.class));
 
 		//When

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -2,6 +2,7 @@ package ssammudan.cotree.domain.education.techbook.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -316,7 +317,8 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 					|| techBook.getDescription().contains(keyword)
 					|| techBook.getIntroduction().contains(keyword))
 			)
-			.sorted(Comparator.comparing(TechBook::getCreatedAt).reversed())
+			.sorted(Comparator.comparing(TechBook::getCreatedAt).reversed()
+				.thenComparing(book -> book.getCreatedAt().truncatedTo(ChronoUnit.MILLIS), Comparator.reverseOrder()))
 			.limit(pageable.getPageSize())
 			.map(TechBookResponse.ListInfo::from)
 			.toList();

--- a/src/test/java/ssammudan/cotree/domain/review/controller/TechEducationReviewControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/review/controller/TechEducationReviewControllerTest.java
@@ -126,7 +126,7 @@ class TechEducationReviewControllerTest extends WebMvcTestSupporter {
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("page", "0");
 		params.add("size", "10");
-		params.add("sort", "createdAt,DESC");
+		params.add("sort", "LATEST");
 		params.add("reviewType", "TECH_TUBE");
 		params.add("itemId", itemId.toString());
 

--- a/src/test/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryTest.java
+++ b/src/test/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryTest.java
@@ -2,6 +2,7 @@ package ssammudan.cotree.model.education.techbook.techbook.repository;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -106,6 +107,14 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 			.sampleList(size);
 	}
 
+	private void sleep(final long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	//@RepeatedTest(10)
 	@Test
 	@DisplayName("[Success] save(): TechBook 엔티티 저장")
@@ -198,7 +207,10 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 		EducationLevel educationLevel = createEducationLevel();
 		entityManager.persist(educationLevel);
 		List<TechBook> techBooks = createTechBooks(member, educationLevel, 50);
-		techBooks.forEach(techBook -> entityManager.persist(techBook));
+		techBooks.forEach(techBook -> {
+			sleep(1);
+			entityManager.persist(techBook);
+		});
 		clearEntityContext();
 
 		String keyword = fixtureMonkey.giveMeOne(String.class);
@@ -214,7 +226,8 @@ class TechBookRepositoryTest extends DataJpaTestSupporter {
 					|| techBook.getDescription().contains(keyword)
 					|| techBook.getIntroduction().contains(keyword))
 			)
-			.sorted(Comparator.comparing(TechBook::getCreatedAt).reversed())
+			.sorted(Comparator.comparing(TechBook::getCreatedAt).reversed()
+				.thenComparing(book -> book.getCreatedAt().truncatedTo(ChronoUnit.MILLIS), Comparator.reverseOrder()))
 			.limit(pageable.getPageSize())
 			.toList();
 


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
close #87
  <br/>

## 🔎 작업 내용
- TechBook, 교육 컨텐츠 리뷰(TechEducationReview) 목록 조회 시 정렬 파라미터 변경
  - Enum 타입 파라미터 활용
  - 각 정렬 조건은 내림차순 기반, 생성일자(createdAt)이 아닐 경우 생성일자 최신순 정렬 조건도 포함
  - 기존 정렬 조건에서 좋아요(Like) 누락 사항 추가

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>