### PR TITLE
[BUG] 커뮤니티 글 작성 성공 후, ID 값 Return 누락 해결

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -49,8 +49,8 @@ public class CommunityController {
 	@PostMapping("/board")
 	@Operation(summary = "커뮤니티 글 작성")
 	public BaseResponse<CommunityResponse.BoardCreate> createNewBoard(
-			@Valid @RequestBody CommunityRequest.CreateBoard createBoard,
-			@AuthenticationPrincipal CustomUser customUser
+		@Valid @RequestBody CommunityRequest.CreateBoard createBoard,
+		@AuthenticationPrincipal CustomUser customUser
 	) {
 		String memberId = customUser.getId();
 

--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -46,14 +46,14 @@ public class CommunityController {
 
 	@PostMapping("/board")
 	@Operation(summary = "커뮤니티 글 작성")
-	public BaseResponse<Void> createNewBoard(
+	public BaseResponse<CommunityResponse.BoardCreate> createNewBoard(
 			@Valid @RequestBody CommunityRequest.CreateBoard createBoard,
 			@AuthenticationPrincipal CustomUser customUser
 	) {
 		String memberId = customUser.getId();
 
-		communityService.createNewBoard(createBoard, memberId);
-		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS);
+		CommunityResponse.BoardCreate boardCreate = communityService.createNewBoard(createBoard, memberId);
+		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS, boardCreate);
 	}
 
 	@GetMapping("/board")

--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
@@ -26,4 +26,10 @@ public class CommunityResponse {
 	public record BoardDetail(String title, String author, LocalDateTime createdAt, String content, Long likeCount,
 							  Integer viewCount, Boolean isLike) {
 	}
+
+	public record BoardCreate(Long boardId) {
+		public static BoardCreate of(Long boardId) {
+			return new BoardCreate(boardId);
+		}
+	}
 }

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityService.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityService.java
@@ -20,7 +20,7 @@ import ssammudan.cotree.global.response.PageResponse;
  * 2025-03-28     Baekgwa               Initial creation
  */
 public interface CommunityService {
-	void createNewBoard(final CommunityRequest.CreateBoard createBoard, final String memberId);
+	CommunityResponse.BoardCreate createNewBoard(final CommunityRequest.CreateBoard createBoard, final String memberId);
 
 	PageResponse<CommunityResponse.BoardListDetail> getBoardList(
 			final Pageable pageable,

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
@@ -41,34 +41,37 @@ public class CommunityServiceImpl implements CommunityService {
 
 	@Transactional
 	@Override
-	public void createNewBoard(CommunityRequest.CreateBoard createBoard, String userId) {
+	public CommunityResponse.BoardCreate createNewBoard(
+		final CommunityRequest.CreateBoard createBoard, final String userId) {
 		// 카테고리 조회 및 유효성 확인
 		CommunityCategory findCommunityCategory = communityCategoryRepository.findByName(createBoard.getCategory())
-				.orElseThrow(() -> new GlobalException(ErrorCode.COMMUNITY_BOARD_CATEGORY_INVALID));
+			.orElseThrow(() -> new GlobalException(ErrorCode.COMMUNITY_BOARD_CATEGORY_INVALID));
 
 		// userId 로 회원 정보 검색
 		Member findMember = memberRepository.findById(userId)
-				.orElseThrow(() -> new GlobalException(ErrorCode.COMMUNITY_MEMBER_NOTFOUND));
+			.orElseThrow(() -> new GlobalException(ErrorCode.COMMUNITY_MEMBER_NOTFOUND));
 
 		// 새 글 저장
 		Community newCommunityBoard =
-				Community.createNewCommunityBoard(findCommunityCategory, findMember, createBoard.getTitle(),
-						createBoard.getContent());
+			Community.createNewCommunityBoard(findCommunityCategory, findMember, createBoard.getTitle(),
+				createBoard.getContent());
 
-		communityRepository.save(newCommunityBoard);
+		//저장 후 응답
+		Community savedCommunity = communityRepository.save(newCommunityBoard);
+		return CommunityResponse.BoardCreate.of(savedCommunity.getId());
 	}
 
 	@Transactional(readOnly = true)
 	@Override
 	public PageResponse<CommunityResponse.BoardListDetail> getBoardList(
-			final Pageable pageable,
-			final SearchBoardSort sort,
-			final SearchBoardCategory category,
-			final String keyword,
-			final String memberId) {
+		final Pageable pageable,
+		final SearchBoardSort sort,
+		final SearchBoardCategory category,
+		final String keyword,
+		final String memberId) {
 
 		Page<CommunityResponse.BoardListDetail> findBoardList =
-				communityRepository.findBoardList(pageable, sort, category, keyword, memberId);
+			communityRepository.findBoardList(pageable, sort, category, keyword, memberId);
 
 		//todo : findBoardList 의 내용 중, Content 들, 글자수 제한 및 이미지 제거 필요.
 		return PageResponse.of(findBoardList);
@@ -79,7 +82,7 @@ public class CommunityServiceImpl implements CommunityService {
 	public CommunityResponse.BoardDetail getBoardDetail(final Long boardId, final String memberId) {
 		// 게시글 정보 조회
 		CommunityResponse.BoardDetail findData = communityRepository.findBoard(boardId, memberId).orElseThrow(
-				() -> new GlobalException(ErrorCode.COMMUNITY_BOARD_NOTFOUND));
+			() -> new GlobalException(ErrorCode.COMMUNITY_BOARD_NOTFOUND));
 
 		// 게시글 조회수 count 업데이트
 		// todo : 게시글 조회수 update 처리


### PR DESCRIPTION
- redirect 용 id 값 return 하도록 변경.
- 기존 : return null;

<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
Closes: #98 
  <br/>

## 🔎 작업 내용
- 커뮤니티 글 작성 성공 후, ID 값 Return 누락 해결
- 기타, 들여쓰기 컨벤션 수정되었습니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>