### PR TITLE
[BUG] S3 파일 업로드 시, URL Encoding 문제 수정

### DIFF
--- a/src/main/java/ssammudan/cotree/infra/s3/S3Uploader.java
+++ b/src/main/java/ssammudan/cotree/infra/s3/S3Uploader.java
@@ -25,6 +25,7 @@ import ssammudan.cotree.global.response.ErrorCode;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-31     Baekgwa               Initial creation
+ * 2025-04-04     Baekgwa               버그로 인한 S3 Upload 시 Encoding 처리 삭제. 대신, 특수문자만 _ 로 replace 진행
  */
 @Slf4j
 @Component
@@ -47,9 +48,8 @@ public class S3Uploader {
 	 * return : 읽기 가능한 저장된 파일 url
 	 */
 	public S3UploadResult upload(String memberId, MultipartFile file, S3Directory directory) {
-		String fileName = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8)
-			.replace("+", "%20");
-
+		String fileName = file.getOriginalFilename()
+			.replaceAll("[^a-zA-Z0-9ㄱ-ㅎ가-힣.-]", "_");
 		String key = fileKeyGenerator(memberId, fileName, directory);
 		try {
 			PutObjectRequest objectRequest = PutObjectRequest


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#104 
  <br/>

## 🔎 작업 내용
- Server 측 S3 파일 저장 시, Encoding 하여 저장하는 방식이, 맞지 않아 presigned url 로 fe(브라우저) 에서 403 발생 확인
- encoding 하지 않고 바로 저장하도록 수정. 단, 특수문자는 위험성이 있어, _ 로 치환
- 개인 S3 로 업로드 및 브라우저에서 로드 확인 완료.
![image](https://github.com/user-attachments/assets/e6cda28f-2dfa-4810-b3d0-d999ce7ab6fd)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>