### PR TITLE
[FIX] techstack image url들 s3 이미지로 변경

### DIFF
--- a/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
+++ b/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
@@ -22,7 +22,8 @@ public enum S3Directory {
 	PROJECT("project/team/", false),
 	EDUCATION_TECHBOOK_MAIN("education/techbook/main/", false),
 	EDUCATION_TECHBOOK_PREVIEW("education/techbook/preview/", false),
-	EDUCATION_TECHBOOK_THUNBNAIL("education/techbook/thumbnail/", false);
+	EDUCATION_TECHBOOK_THUNBNAIL("education/techbook/thumbnail/", false),
+	TECHSTACK("techstack/", false);
 
 	private final String path;
 	private final boolean isMultiFile;

--- a/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
+++ b/src/main/java/ssammudan/cotree/infra/s3/S3Directory.java
@@ -22,8 +22,7 @@ public enum S3Directory {
 	PROJECT("project/team/", false),
 	EDUCATION_TECHBOOK_MAIN("education/techbook/main/", false),
 	EDUCATION_TECHBOOK_PREVIEW("education/techbook/preview/", false),
-	EDUCATION_TECHBOOK_THUNBNAIL("education/techbook/thumbnail/", false),
-	TECHSTACK("techstack/", false);
+	EDUCATION_TECHBOOK_THUNBNAIL("education/techbook/thumbnail/", false);
 
 	private final String path;
 	private final boolean isMultiFile;

--- a/src/main/resources/db/seed/dev/R__A_insert_seed.sql
+++ b/src/main/resources/db/seed/dev/R__A_insert_seed.sql
@@ -1,18 +1,18 @@
 INSERT INTO tech_stack (name, image_url)
-VALUES ('Java', 'https://worldvectorlogo.com/download/java.svg'),
-       ('Kotlin', 'https://worldvectorlogo.com/download/kotlin-1.svg'),
-       ('Spring', 'https://worldvectorlogo.com/download/spring-3.svg'),
-       ('Spring Boot', 'https://worldvectorlogo.com/download/spring-boot-1.svg'),
-       ('JavaScript', 'https://worldvectorlogo.com/download/javascript-2.svg'),
-       ('React', 'https://worldvectorlogo.com/download/react-2.svg'),
-       ('Typescript', 'https://worldvectorlogo.com/download/typescript.svg'),
-       ('Django', 'https://worldvectorlogo.com/download/django.svg'),
-       ('MySQL', 'https://worldvectorlogo.com/download/mysql-3.svg'),
-       ('MariaDB', 'https://worldvectorlogo.com/download/mariadb.svg'),
-       ('PostgreSQL', 'https://worldvectorlogo.com/download/postgresql.svg'),
-       ('MongoDB', 'https://worldvectorlogo.com/download/mongodb-icon-1.svg'),
-       ('AWS', 'https://worldvectorlogo.com/download/aws-2.svg'),
-       ('Node.js', 'https://worldvectorlogo.com/download/nodejs.svg');
+VALUES ('Java', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/java.svg'),
+       ('Kotlin', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/kotlin-1.svg'),
+       ('Spring', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/spring-3.svg'),
+       ('Spring Boot', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/spring-boot-1.svg'),
+       ('JavaScript', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/javascript-2.svg'),
+       ('React', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/react-2.svg'),
+       ('Typescript', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/typescript.svg'),
+       ('Django', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/django.svg'),
+       ('MySQL', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mysql-3.svg'),
+       ('MariaDB', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mariadb.svg'),
+       ('PostgreSQL', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/postgresql.svg'),
+       ('MongoDB', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mongodb-icon-1.svg'),
+       ('AWS', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/aws-2.svg'),
+       ('Node.js', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/nodejs.svg');
 
 INSERT INTO development_position (name)
 VALUES ('프론트엔드'),

--- a/src/main/resources/db/seed/prod/R__A_insert_seed.sql
+++ b/src/main/resources/db/seed/prod/R__A_insert_seed.sql
@@ -1,18 +1,18 @@
 INSERT INTO tech_stack (name, image_url)
-VALUES ('Java', 'https://worldvectorlogo.com/download/java.svg'),
-       ('Kotlin', 'https://worldvectorlogo.com/download/kotlin-1.svg'),
-       ('Spring', 'https://worldvectorlogo.com/download/spring-3.svg'),
-       ('Spring Boot', 'https://worldvectorlogo.com/download/spring-boot-1.svg'),
-       ('JavaScript', 'https://worldvectorlogo.com/download/javascript-2.svg'),
-       ('React', 'https://worldvectorlogo.com/download/react-2.svg'),
-       ('Typescript', 'https://worldvectorlogo.com/download/typescript.svg'),
-       ('Django', 'https://worldvectorlogo.com/download/django.svg'),
-       ('MySQL', 'https://worldvectorlogo.com/download/mysql-3.svg'),
-       ('MariaDB', 'https://worldvectorlogo.com/download/mariadb.svg'),
-       ('PostgreSQL', 'https://worldvectorlogo.com/download/postgresql.svg'),
-       ('MongoDB', 'https://worldvectorlogo.com/download/mongodb-icon-1.svg'),
-       ('AWS', 'https://worldvectorlogo.com/download/aws-2.svg'),
-       ('Node.js', 'https://worldvectorlogo.com/download/nodejs.svg');
+VALUES ('Java', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/java.svg'),
+       ('Kotlin', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/kotlin-1.svg'),
+       ('Spring', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/spring-3.svg'),
+       ('Spring Boot', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/spring-boot-1.svg'),
+       ('JavaScript', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/javascript-2.svg'),
+       ('React', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/react-2.svg'),
+       ('Typescript', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/typescript.svg'),
+       ('Django', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/django.svg'),
+       ('MySQL', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mysql-3.svg'),
+       ('MariaDB', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mariadb.svg'),
+       ('PostgreSQL', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/postgresql.svg'),
+       ('MongoDB', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/mongodb-icon-1.svg'),
+       ('AWS', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/aws-2.svg'),
+       ('Node.js', 'https://devcouse4-team15-bucket.s3.ap-northeast-2.amazonaws.com/techstack/nodejs.svg');
 
 INSERT INTO development_position (name)
 VALUES ('프론트엔드'),


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
Closes #118 
  <br/>

## 🔎 작업 내용
- 기존이미지가 다운로드하는 이미지 url이였어서 s3에 업로드한 이미지 url로 변경했습니다.
  - 서버db의 techstack image url 변경 완료했습니다.
  - 프론트측에서 이미지 잘 나오는거 확인했습니다.
  <br/>