### PR TITLE
[FEAT] 프로젝트 조회 queryDSL 적용 및 최적화

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -1,5 +1,11 @@
 package ssammudan.cotree.domain.project.controller;
 
+import java.util.List;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
@@ -28,7 +35,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * FileName    : ProjectController
  * Author      : sangxxjin
  * Date        : 2025. 4. 2.
- * Description : 
+ * Description : 프로젝트 컨트롤러
  * =====================================================================================================================
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
@@ -66,6 +73,25 @@ public class ProjectController {
 		ProjectInfoResponse response = projectServiceImpl.getProjectInfo(projectId, memberId);
 
 		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS, response);
+	}
+
+	@GetMapping("/hot/main")
+	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	public BaseResponse<List<HotProjectResponse>> getHotProjectsForMain(
+		@ParameterObject @PageableDefault(page = 0, size = 4, sort = {"viewCount",
+			"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS,
+			projectServiceImpl.getHotProjectsForMain(pageable));
+	}
+
+	@GetMapping("/hot")
+	@Operation(summary = "프로젝트 페이지 HOT 프로젝트 조회", description = "프로젝트 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	public BaseResponse<List<HotProjectResponse>> getHotProjectsForProject() {
+		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS,
+			projectServiceImpl.getHotProjectsForProject());
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -2,11 +2,8 @@ package ssammudan.cotree.domain.project.controller;
 
 import java.util.List;
 
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -91,7 +88,7 @@ public class ProjectController {
 	}
 
 	@GetMapping("/hot")
-	@Operation(summary = "프로젝트 페이지 HOT 프로젝트 조회", description = "프로젝트 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
+	@Operation(summary = "프로젝트 페이지 HOT 프로젝트 조회", description = "프로젝트 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.(조회수, 좋아요 기준)")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	public BaseResponse<List<ProjectListResponse>> getHotProjectsForProject() {
 		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS,
@@ -99,7 +96,7 @@ public class ProjectController {
 	}
 
 	@GetMapping
-	@Operation(summary = "프로젝트 목록 조회", description = "프로젝트 목록을 조회합니다.")
+	@Operation(summary = "프로젝트 목록 조회", description = "프로젝트 목록을 조회합니다.(최신순, 좋아요순 선택 - default 최신순)")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	public BaseResponse<PageResponse<ProjectListResponse>> getProjects(
 		@RequestParam(value = "page", defaultValue = "0", required = false) int page,

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -79,12 +79,13 @@ public class ProjectController {
 	}
 
 	@GetMapping("/hot/main")
-	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.(조회수, 작성일 기준)")
+	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.(조회수, 좋아요 기준)")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	public BaseResponse<PageResponse<ProjectListResponse>> getHotProjectsForMain(
-		@ParameterObject @PageableDefault(page = 0, size = 4, sort = {"viewCount",
-			"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "4") int size
 	) {
+		Pageable pageable = PageRequest.of(page, size);
 		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS,
 			projectServiceImpl.getHotProjectsForMain(pageable));
 	}

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -3,7 +3,6 @@ package ssammudan.cotree.domain.project.controller;
 import java.util.List;
 
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -109,9 +108,8 @@ public class ProjectController {
 		@RequestParam(value = "jobPosition", required = false) List<Long> devPositionIds
 	) {
 		Pageable pageable = PageRequest.of(page, size);
-		Page<ProjectListResponse> hotProjects = projectServiceImpl.getProjects(pageable, techStackIds, devPositionIds,
-			sort);
-		return BaseResponse.success(SuccessCode.PROJECT_LIST_SEARCH_SUCCESS, PageResponse.of(hotProjects));
+		return BaseResponse.success(SuccessCode.PROJECT_LIST_SEARCH_SUCCESS,
+			projectServiceImpl.getProjects(pageable, techStackIds, devPositionIds, sort));
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -94,5 +94,21 @@ public class ProjectController {
 			projectServiceImpl.getHotProjectsForProject());
 	}
 
+	@GetMapping
+	@Operation(summary = "프로젝트 목록 조회", description = "프로젝트 목록을 조회합니다.")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	public BaseResponse<PageResponse<ProjectListResponse>> getProjects(
+		@RequestParam(value = "page", defaultValue = "0", required = false) int page,
+		@RequestParam(value = "size", defaultValue = "12", required = false) int size,
+		@RequestParam(value = "sort", defaultValue = "createdAt", required = false) String sort,
+		@RequestParam(value = "techStack", required = false) List<Long> techStackIds,
+		@RequestParam(value = "jobPosition", required = false) List<Long> devPositionIds
+	) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<ProjectListResponse> hotProjects = projectServiceImpl.getProjects(pageable, techStackIds, devPositionIds,
+			sort);
+		return BaseResponse.success(SuccessCode.PROJECT_LIST_SEARCH_SUCCESS, PageResponse.of(hotProjects));
+	}
+
 }
 

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -105,7 +105,7 @@ public class ProjectController {
 		@RequestParam(value = "size", defaultValue = "12", required = false) int size,
 		@RequestParam(value = "sort", defaultValue = "createdAt", required = false) String sort,
 		@RequestParam(value = "techStack", required = false) List<Long> techStackIds,
-		@RequestParam(value = "jobPosition", required = false) List<Long> devPositionIds
+		@RequestParam(value = "devPosition", required = false) List<Long> devPositionIds
 	) {
 		Pageable pageable = PageRequest.of(page, size);
 		return BaseResponse.success(SuccessCode.PROJECT_LIST_SEARCH_SUCCESS,

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -89,8 +89,8 @@ public class ProjectController {
 	@GetMapping("/hot")
 	@Operation(summary = "프로젝트 페이지 HOT 프로젝트 조회", description = "프로젝트 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
-	public BaseResponse<List<HotProjectResponse>> getHotProjectsForProject() {
-		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS,
+	public BaseResponse<List<ProjectListResponse>> getHotProjectsForProject() {
+		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS,
 			projectServiceImpl.getHotProjectsForProject());
 	}
 

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -80,14 +80,14 @@ public class ProjectController {
 	}
 
 	@GetMapping("/hot/main")
-	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
+	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.(조회수, 작성일 기준)")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
 	public BaseResponse<PageResponse<ProjectListResponse>> getHotProjectsForMain(
 		@ParameterObject @PageableDefault(page = 0, size = 4, sort = {"viewCount",
 			"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		Page<ProjectListResponse> hotProjects = projectServiceImpl.getHotProjectsForMain(pageable);
-		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS, PageResponse.of(hotProjects));
+		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS,
+			projectServiceImpl.getHotProjectsForMain(pageable));
 	}
 
 	@GetMapping("/hot")

--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -3,6 +3,8 @@ package ssammudan.cotree.domain.project.controller;
 import java.util.List;
 
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,13 +24,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
+import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 
 /**
@@ -78,12 +82,12 @@ public class ProjectController {
 	@GetMapping("/hot/main")
 	@Operation(summary = "메인페이지 HOT 프로젝트 조회", description = "메인 페이지에서 인기 있는 HOT 프로젝트 목록을 조회합니다.")
 	@ApiResponse(responseCode = "200", description = "조회 성공")
-	public BaseResponse<List<HotProjectResponse>> getHotProjectsForMain(
+	public BaseResponse<PageResponse<ProjectListResponse>> getHotProjectsForMain(
 		@ParameterObject @PageableDefault(page = 0, size = 4, sort = {"viewCount",
 			"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		return BaseResponse.success(SuccessCode.PROJECT_FETCH_SUCCESS,
-			projectServiceImpl.getHotProjectsForMain(pageable));
+		Page<ProjectListResponse> hotProjects = projectServiceImpl.getHotProjectsForMain(pageable);
+		return BaseResponse.success(SuccessCode.PROJECT_HOT_LIST_SEARCH_SUCCESS, PageResponse.of(hotProjects));
 	}
 
 	@GetMapping("/hot")

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
@@ -20,7 +20,7 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * 2025. 4. 3.     sangxxjin               Initial creation
  */
 @Builder(access = AccessLevel.PRIVATE)
-public record HotProjectResponse(
+public record ProjectListResponse(
 	Long id,
 	String title,
 	String description,
@@ -34,10 +34,10 @@ public record HotProjectResponse(
 	String username,
 	String userProfileImageUrl
 ) {
-	public static HotProjectResponse from(Project project, List<String> techStacksImageUrl, long likeCount,
+	public static ProjectListResponse from(Project project, List<String> techStacksImageUrl, long likeCount,
 		Member member,
 		int recruitmentCount) {
-		return HotProjectResponse.builder()
+		return ProjectListResponse.builder()
 			.id(project.getId())
 			.title(project.getTitle())
 			.description(project.getDescription().length() > 30 ? project.getDescription().substring(0, 30) + "..." :

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
@@ -3,11 +3,6 @@ package ssammudan.cotree.domain.project.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import ssammudan.cotree.model.member.member.entity.Member;
-import ssammudan.cotree.model.project.project.entity.Project;
-
 /**
  * PackageName : ssammudan.cotree.domain.project.dto
  * FileName    : HotProjectResponse
@@ -19,7 +14,6 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 3.     sangxxjin               Initial creation
  */
-@Builder(access = AccessLevel.PRIVATE)
 public record ProjectListResponse(
 	Long id,
 	String title,
@@ -35,24 +29,4 @@ public record ProjectListResponse(
 	String username,
 	String userProfileImageUrl
 ) {
-	public static ProjectListResponse from(Project project, List<String> techStacksImageUrl, long likeCount,
-		Member member,
-		int recruitmentCount) {
-		return ProjectListResponse.builder()
-			.id(project.getId())
-			.title(project.getTitle())
-			.description(project.getDescription().length() > 30 ? project.getDescription().substring(0, 30) + "..." :
-				project.getDescription())
-			.imageUrl(project.getProjectImageUrl())
-			.viewCount(project.getViewCount())
-			.likeCount(likeCount)
-			.recruitmentCount(recruitmentCount)
-			.isOpen(project.getIsOpen())
-			.startDate(project.getStartDate())
-			.endDate(project.getEndDate())
-			.techStacksImageUrl(techStacksImageUrl)
-			.username(member.getUsername())
-			.userProfileImageUrl(member.getProfileImageUrl())
-			.build();
-	}
 }

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectListResponse.java
@@ -28,6 +28,7 @@ public record ProjectListResponse(
 	int viewCount,
 	long likeCount,
 	int recruitmentCount,
+	boolean isOpen,
 	LocalDate startDate,
 	LocalDate endDate,
 	List<String> techStacksImageUrl,
@@ -46,6 +47,7 @@ public record ProjectListResponse(
 			.viewCount(project.getViewCount())
 			.likeCount(likeCount)
 			.recruitmentCount(recruitmentCount)
+			.isOpen(project.getIsOpen())
 			.startDate(project.getStartDate())
 			.endDate(project.getEndDate())
 			.techStacksImageUrl(techStacksImageUrl)

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -1,14 +1,13 @@
 package ssammudan.cotree.domain.project.service;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
-import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
+import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 
 /**
  * PackageName : ssammudan.cotree.domain.project.service
@@ -26,7 +25,7 @@ import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 public interface ProjectService {
 	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
 
-	List<HotProjectResponse> getHotProjectsForMain(Pageable pageable);
+	Page<ProjectListResponse> getHotProjectsForMain(Pageable pageable);
 
 	ProjectInfoResponse getProjectInfo(Long projectId, String memberId);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -1,6 +1,5 @@
 package ssammudan.cotree.domain.project.service;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,6 +7,7 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.global.response.PageResponse;
 
 /**
  * PackageName : ssammudan.cotree.domain.project.service
@@ -25,7 +25,7 @@ import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 public interface ProjectService {
 	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
 
-	Page<ProjectListResponse> getHotProjectsForMain(Pageable pageable);
+	PageResponse<ProjectListResponse> getHotProjectsForMain(Pageable pageable);
 
 	ProjectInfoResponse getProjectInfo(Long projectId, String memberId);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package ssammudan.cotree.domain.project.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import ssammudan.cotree.domain.project.dto.HotProjectResponse;
@@ -25,7 +26,7 @@ import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 public interface ProjectService {
 	ProjectCreateResponse create(ProjectCreateRequest request, MultipartFile file, String memberId);
 
-	List<HotProjectResponse> getHotProjects();
+	List<HotProjectResponse> getHotProjectsForMain(Pageable pageable);
 
 	ProjectInfoResponse getProjectInfo(Long projectId, String memberId);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -1,5 +1,7 @@
 package ssammudan.cotree.domain.project.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,4 +30,8 @@ public interface ProjectService {
 	PageResponse<ProjectListResponse> getHotProjectsForMain(Pageable pageable);
 
 	ProjectInfoResponse getProjectInfo(Long projectId, String memberId);
+
+	PageResponse<ProjectListResponse> getProjects(Pageable pageable, List<Long> techStackIds,
+		List<Long> devPositionIds,
+		String sort);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -13,10 +13,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import ssammudan.cotree.domain.project.dto.HotProjectResponse;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
+import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.infra.s3.S3Directory;
@@ -115,9 +115,13 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<HotProjectResponse> getHotProjectsForMain(Pageable pageable) {
+	public Page<ProjectListResponse> getHotProjectsForMain(Pageable pageable) {
 		Page<Project> projects = projectRepository.findByIsOpenTrue(pageable);
-		return projects.stream().map(this::toHotProjectResponse).toList();
+		List<ProjectListResponse> hotPojectListRespons = projects.stream()
+			.map(this::toProjectResponse)
+			.toList();
+
+		return new PageImpl<>(hotPojectListRespons, pageable, projects.getTotalElements());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,6 +46,7 @@ import ssammudan.cotree.model.project.techstack.repository.ProjectTechStackRepos
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     sangxxjin          create project 구현
+ * 2025. 4. 2.     sangxxjin          get project 구현
  */
 @Service
 @RequiredArgsConstructor
@@ -111,11 +114,19 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<HotProjectResponse> getHotProjects() {
+	public List<HotProjectResponse> getHotProjectsForMain(Pageable pageable) {
+		Page<Project> projects = projectRepository.findByIsOpenTrue(pageable);
+		return projects.stream().map(this::toHotProjectResponse).toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<HotProjectResponse> getHotProjectsForProject() {
+		//todo: 캐싱 작업
 		return projectRepository.findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc().stream()
 			.map(this::toHotProjectResponse)
 			.toList();
 	}
+
 	// 모집분야명, 인원수 조회
 	private List<Map<String, Integer>> getDevPositionsInfo(Long projectId) {
 		return projectDevPositionRepository.findByProjectId(projectId).stream()
@@ -160,7 +171,6 @@ public class ProjectServiceImpl implements ProjectService {
 			.mapToInt(ProjectDevPosition::getAmount)
 			.sum();
 	}
-
 
 	private List<TechStack> getTechStackNames(ProjectCreateRequest request) {
 		return techStackRepository.findByIds(request.techStackIds());

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -168,7 +168,7 @@ public class ProjectServiceImpl implements ProjectService {
 	private ProjectListResponse toProjectResponse(Project project) {
 		List<String> techStackImageUrls = getTechStackImageUrls(project.getId());
 		long likeCount = likeRepository.countByProjectId(project.getId());
-		Member member = memberRepository.findById(project.getMember().getId()).orElse(null);
+		Member member = project.getMember();
 		int recruitmentCount = getRecruitmentCount(project.getId());
 
 		return ProjectListResponse.from(project, techStackImageUrls, likeCount, member, recruitmentCount);

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -125,6 +126,17 @@ public class ProjectServiceImpl implements ProjectService {
 		return projectRepository.findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc().stream()
 			.map(this::toProjectResponse)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public Page<ProjectListResponse> getProjects(Pageable pageable, List<Long> techStackIds, List<Long> devPositionIds,
+		String sort) {
+		Page<Project> projects = projectRepository.findByFilters(pageable, techStackIds, devPositionIds, sort);
+		List<ProjectListResponse> projectListResponse = projects.getContent().stream()
+			.map(this::toProjectResponse)
+			.toList();
+
+		return new PageImpl<>(projectListResponse, pageable, projects.getTotalElements());
 	}
 
 	// 모집분야명, 인원수 조회

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -135,14 +135,16 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ProjectListResponse> getProjects(Pageable pageable, List<Long> techStackIds, List<Long> devPositionIds,
+	public PageResponse<ProjectListResponse> getProjects(Pageable pageable, List<Long> techStackIds,
+		List<Long> devPositionIds,
 		String sort) {
 		Page<Project> projects = projectRepository.findByFilters(pageable, techStackIds, devPositionIds, sort);
-		List<ProjectListResponse> projectListResponse = projects.getContent().stream()
+		List<ProjectListResponse> content = projects.getContent().stream()
 			.map(this::toProjectResponse)
 			.toList();
 
-		return new PageImpl<>(projectListResponse, pageable, projects.getTotalElements());
+		Page<ProjectListResponse> page = new PageImpl<>(content, pageable, projects.getTotalElements());
+		return PageResponse.of(page);
 	}
 
 	// 모집분야명, 인원수 조회
@@ -162,7 +164,7 @@ public class ProjectServiceImpl implements ProjectService {
 			.toList();
 	}
 
-	// Hot프로젝트 데이터가공
+	// 프로젝트 데이터가공
 	private ProjectListResponse toProjectResponse(Project project) {
 		List<String> techStackImageUrls = getTechStackImageUrls(project.getId());
 		long likeCount = likeRepository.countByProjectId(project.getId());

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -120,10 +120,10 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<HotProjectResponse> getHotProjectsForProject() {
+	public List<ProjectListResponse> getHotProjectsForProject() {
 		//todo: 캐싱 작업
 		return projectRepository.findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc().stream()
-			.map(this::toHotProjectResponse)
+			.map(this::toProjectResponse)
 			.toList();
 	}
 
@@ -145,13 +145,13 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	// Hot프로젝트 데이터가공
-	private HotProjectResponse toHotProjectResponse(Project project) {
+	private ProjectListResponse toProjectResponse(Project project) {
 		List<String> techStackImageUrls = getTechStackImageUrls(project.getId());
 		long likeCount = likeRepository.countByProjectId(project.getId());
 		Member member = memberRepository.findById(project.getMember().getId()).orElse(null);
 		int recruitmentCount = getRecruitmentCount(project.getId());
 
-		return HotProjectResponse.from(project, techStackImageUrls, likeCount, member, recruitmentCount);
+		return ProjectListResponse.from(project, techStackImageUrls, likeCount, member, recruitmentCount);
 	}
 
 	// 프로젝트에 해당하는 techstack들의 이미지들 가져오는 메서드

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -19,6 +19,7 @@ import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.infra.s3.S3Directory;
 import ssammudan.cotree.infra.s3.S3Uploader;
 import ssammudan.cotree.model.common.developmentposition.entity.DevelopmentPosition;
@@ -115,13 +116,14 @@ public class ProjectServiceImpl implements ProjectService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ProjectListResponse> getHotProjectsForMain(Pageable pageable) {
+	public PageResponse<ProjectListResponse> getHotProjectsForMain(Pageable pageable) {
 		Page<Project> projects = projectRepository.findByIsOpenTrue(pageable);
-		List<ProjectListResponse> hotPojectListRespons = projects.stream()
+		List<ProjectListResponse> hotPojectList = projects.stream()
 			.map(this::toProjectResponse)
 			.toList();
 
-		return new PageImpl<>(hotPojectListRespons, pageable, projects.getTotalElements());
+		Page<ProjectListResponse> hotProjectPage = new PageImpl<>(hotPojectList, pageable, projects.getTotalElements());
+		return PageResponse.of(hotProjectPage);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -98,6 +98,7 @@ public class SecurityConfig {
 
 				// Project Domain
 				.requestMatchers(GET, "/api/v1/project/team/hot").permitAll()
+				.requestMatchers(GET, "/api/v1/project/team/hot/main").permitAll()
 				.requestMatchers(GET, "/api/v1/project/team/{projectId}").permitAll()
 
 				// Upload Domain

--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -97,9 +97,8 @@ public class SecurityConfig {
 				.requestMatchers(GET, "/api/v1/recruitment/resume/**").permitAll()
 
 				// Project Domain
-				.requestMatchers(GET, "/api/v1/project/team/hot").permitAll()
-				.requestMatchers(GET, "/api/v1/project/team/hot/main").permitAll()
-				.requestMatchers(GET, "/api/v1/project/team/{projectId}").permitAll()
+				.requestMatchers(GET, "/api/v1/project/team").permitAll()
+				.requestMatchers(GET, "/api/v1/project/team/**").permitAll()
 
 				// Upload Domain
 				// 해당 없음. 모두 인증 필요

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -30,7 +30,8 @@ public enum SuccessCode {
 
 	//Project
 	PROJECT_CREATE_SUCCESS(HttpStatus.CREATED, "201", "프로젝트 생성 성공"),
-	PROJECT_HOT_LIST_SEARCH_SUCCESS(HttpStatus.OK, "200", "Hot 프로젝트 조회 성공"),
+	PROJECT_HOT_LIST_SEARCH_SUCCESS(HttpStatus.OK, "200", "Hot 프로젝트 목록 조회 성공"),
+	PROJECT_LIST_SEARCH_SUCCESS(HttpStatus.OK, "200", "프로젝트 목록 조회 성공"),
 	PROJECT_FETCH_SUCCESS(HttpStatus.OK, "200", "프로젝트 상세 조회 성공"),
 
 	//Community

--- a/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -56,9 +57,11 @@ public class Project extends BaseEntity {
 	private Member member;
 
 	@OneToMany(mappedBy = "project")
+	@OrderBy("techStack.id ASC")
 	private Set<ProjectTechStack> projectTechStacks;
 
 	@OneToMany(mappedBy = "project")
+	@OrderBy("developmentPosition.id ASC")
 	private Set<ProjectDevPosition> projectDevPositions;
 
 	@OneToMany(mappedBy = "project")

--- a/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
@@ -1,6 +1,7 @@
 package ssammudan.cotree.model.project.project.entity;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +20,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.global.entity.BaseEntity;
+import ssammudan.cotree.model.common.like.entity.Like;
 import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
+import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
 
 /**
  * PackageName : ssammudan.cotree.model.project.project.entity
@@ -48,6 +53,15 @@ public class Project extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
+
+	@OneToMany(mappedBy = "project")
+	private Set<ProjectTechStack> projectTechStacks;
+
+	@OneToMany(mappedBy = "project")
+	private Set<ProjectDevPosition> projectDevPositions;
+
+	@OneToMany(mappedBy = "project")
+	private Set<Like> likes;
 
 	@Column(name = "title", nullable = false)
 	private String title;

--- a/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/entity/Project.java
@@ -23,6 +23,7 @@ import ssammudan.cotree.global.entity.BaseEntity;
 import ssammudan.cotree.model.common.like.entity.Like;
 import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
+import ssammudan.cotree.model.project.membership.entity.ProjectMembership;
 import ssammudan.cotree.model.project.techstack.entity.ProjectTechStack;
 
 /**
@@ -59,6 +60,9 @@ public class Project extends BaseEntity {
 
 	@OneToMany(mappedBy = "project")
 	private Set<ProjectDevPosition> projectDevPositions;
+
+	@OneToMany(mappedBy = "project")
+	private Set<ProjectMembership> projectMemberships;
 
 	@OneToMany(mappedBy = "project")
 	private Set<Like> likes;

--- a/src/main/java/ssammudan/cotree/model/project/project/helper/ProjectQueryHelper.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/helper/ProjectQueryHelper.java
@@ -1,0 +1,106 @@
+package ssammudan.cotree.model.project.project.helper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.model.common.like.entity.QLike;
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
+import ssammudan.cotree.model.project.devposition.entity.QProjectDevPosition;
+import ssammudan.cotree.model.project.project.entity.Project;
+import ssammudan.cotree.model.project.project.entity.QProject;
+import ssammudan.cotree.model.project.techstack.entity.QProjectTechStack;
+
+/**
+ * PackageName : ssammudan.cotree.model.project.project.helper
+ * FileName    : ProjectQueryHelper
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 7.
+ * Description : query를 도와줄 helper클래스 적용
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 7.     sangxxjin               Initial creation
+ */
+@Component
+@RequiredArgsConstructor
+
+public class ProjectQueryHelper {
+
+	private final JPAQueryFactory queryFactory;
+
+	public BooleanBuilder buildFilterConditions(List<Long> techStackIds, List<Long> devPositionIds) {
+		BooleanBuilder where = new BooleanBuilder();
+		if (techStackIds != null && !techStackIds.isEmpty()) {
+			where.and(QProjectTechStack.projectTechStack.techStack.id.in(techStackIds));
+		}
+		if (devPositionIds != null && !devPositionIds.isEmpty()) {
+			where.and(QProjectDevPosition.projectDevPosition.developmentPosition.id.in(devPositionIds));
+		}
+		return where;
+	}
+
+	public List<ProjectListResponse> convertToDtoOrdered(List<Project> projects, List<Long> orderedIds) {
+		Map<Long, ProjectListResponse> projectDtoMap = projects.stream()
+			.collect(Collectors.toMap(Project::getId, this::toDto));
+
+		return orderedIds.stream()
+			.map(projectDtoMap::get)
+			.toList();
+	}
+
+	private ProjectListResponse toDto(Project p) {
+		List<String> techStacksImageUrl = p.getProjectTechStacks().stream()
+			.map(ts -> ts.getTechStack().getImageUrl())
+			.toList();
+
+		long likeCount = p.getLikes().size();
+		int recruitmentCount = p.getProjectDevPositions().stream()
+			.mapToInt(ProjectDevPosition::getAmount).sum();
+
+		String description = p.getDescription();
+		if (description.length() > 30) {
+			description = description.substring(0, 30) + "...";
+		}
+
+		return new ProjectListResponse(
+			p.getId(),
+			p.getTitle(),
+			description,
+			p.getProjectImageUrl(),
+			p.getViewCount(),
+			likeCount,
+			recruitmentCount,
+			p.getIsOpen(),
+			p.getStartDate(),
+			p.getEndDate(),
+			techStacksImageUrl,
+			p.getMember().getUsername(),
+			p.getMember().getProfileImageUrl()
+		);
+	}
+
+	public List<Long> sortFilteredProjects(List<Long> ids, String sort, Pageable pageable) {
+		return queryFactory.select(QProject.project.id)
+			.from(QProject.project)
+			.leftJoin(QProject.project.likes, QLike.like)
+			.where(QProject.project.id.in(ids))
+			.groupBy(QProject.project.id)
+			.orderBy(
+				"like".equalsIgnoreCase(sort)
+					? QLike.like.id.count().desc()
+					: QProject.project.createdAt.desc()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+}

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
@@ -2,6 +2,8 @@ package ssammudan.cotree.model.project.project.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.project.entity.Project;
@@ -20,4 +22,6 @@ import ssammudan.cotree.model.project.project.entity.Project;
  */
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 	List<Project> findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc();
+
+	Page<Project> findByIsOpenTrue(Pageable pageable);
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
@@ -20,7 +20,7 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * 2025-03-29     Baekgwa               Initial creation
  * 2025-04-02    sangxxjin             get HotProject
  */
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
 	List<Project> findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc();
 
 	Page<Project> findByIsOpenTrue(Pageable pageable);

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepository.java
@@ -1,9 +1,5 @@
 package ssammudan.cotree.model.project.project.repository;
 
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.project.project.entity.Project;
@@ -21,7 +17,4 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * 2025-04-02    sangxxjin             get HotProject
  */
 public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectRepositoryCustom {
-	List<Project> findTop2ByIsOpenTrueOrderByViewCountDescCreatedAtDesc();
-
-	Page<Project> findByIsOpenTrue(Pageable pageable);
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
@@ -1,0 +1,23 @@
+package ssammudan.cotree.model.project.project.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.model.project.project.entity.Project;
+
+/**
+ * PackageName : ssammudan.cotree.model.project.project.repository
+ * FileName    : ProjectRepositoryCustom
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 4.
+ * Description : CustomRepository
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 4.     sangxxjin               Initial creation
+ */
+public interface ProjectRepositoryCustom {
+	Page<Project> findByFilters(Pageable pageable, List<Long> techStackIds, List<Long> devPositionIds, String sort);
+}

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
@@ -1,11 +1,13 @@
 package ssammudan.cotree.model.project.project.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.model.project.project.entity.Project;
 
 /**
  * PackageName : ssammudan.cotree.model.project.project.repository
@@ -19,6 +21,10 @@ import ssammudan.cotree.domain.project.dto.ProjectListResponse;
  * 2025. 4. 4.     sangxxjin               Initial creation
  */
 public interface ProjectRepositoryCustom {
+	Optional<Project> fetchProjectDetailById(Long projectId);
+
+	Optional<Project> fetchProjectDetailById(Long projectId, String memberId);
+
 	Page<ProjectListResponse> findHotProjectsForMain(Pageable pageable);
 
 	List<ProjectListResponse> findHotProjectsForProject(int limit);

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import ssammudan.cotree.model.project.project.entity.Project;
+import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 
 /**
  * PackageName : ssammudan.cotree.model.project.project.repository
@@ -19,5 +19,10 @@ import ssammudan.cotree.model.project.project.entity.Project;
  * 2025. 4. 4.     sangxxjin               Initial creation
  */
 public interface ProjectRepositoryCustom {
-	Page<Project> findByFilters(Pageable pageable, List<Long> techStackIds, List<Long> devPositionIds, String sort);
+	Page<ProjectListResponse> findHotProjectsForMain(Pageable pageable);
+
+	List<ProjectListResponse> findHotProjectsForProject(int limit);
+
+	Page<ProjectListResponse> findByFilters(Pageable pageable, List<Long> techStackIds,
+		List<Long> devPositionIds, String sort);
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
@@ -1,8 +1,6 @@
 package ssammudan.cotree.model.project.project.repository;
 
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -133,19 +131,18 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 	}
 
 	private List<ProjectListResponse> convertToDtoOrdered(List<Project> projects, List<Long> orderedIds) {
-		Map<Long, Integer> orderMap = new HashMap<>();
-		for (int i = 0; i < orderedIds.size(); i++) {
-			orderMap.put(orderedIds.get(i), i);
-		}
-		projects.sort(Comparator.comparingInt(p -> orderMap.get(p.getId())));
+		Map<Long, ProjectListResponse> projectDtoMap = projects.stream()
+			.collect(Collectors.toMap(Project::getId, this::toDto));
 
-		return projects.stream().map(this::toDto).collect(Collectors.toList());
+		return orderedIds.stream()
+			.map(projectDtoMap::get)
+			.toList();
 	}
 
 	private ProjectListResponse toDto(Project p) {
 		List<String> techStacksImageUrl = p.getProjectTechStacks().stream()
 			.map(ts -> ts.getTechStack().getImageUrl())
-			.collect(Collectors.toList());
+			.toList();
 
 		long likeCount = p.getLikes().size();
 		int recruitmentCount = p.getProjectDevPositions().stream()

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
@@ -39,6 +39,7 @@ import ssammudan.cotree.model.project.techstack.entity.QProjectTechStack;
 public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
+	private static final String SORT_BY_LIKE = "like";
 
 	public ProjectRepositoryImpl(EntityManager em) {
 		this.queryFactory = new JPAQueryFactory(em);
@@ -190,7 +191,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			.where(QProject.project.id.in(ids))
 			.groupBy(QProject.project.id)
 			.orderBy(
-				"like".equalsIgnoreCase(sort)
+				SORT_BY_LIKE.equalsIgnoreCase(sort)
 					? QLike.like.id.count().desc()
 					: QProject.project.createdAt.desc()
 			)

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
@@ -1,0 +1,101 @@
+package ssammudan.cotree.model.project.project.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import ssammudan.cotree.model.common.like.entity.QLike;
+import ssammudan.cotree.model.project.devposition.entity.QProjectDevPosition;
+import ssammudan.cotree.model.project.project.entity.Project;
+import ssammudan.cotree.model.project.project.entity.QProject;
+import ssammudan.cotree.model.project.techstack.entity.QProjectTechStack;
+
+/**
+ * PackageName : ssammudan.cotree.model.project.project.repository
+ * FileName    : ProjectRepositoryImpl
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 4.
+ * Description : QueryDSL
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 4.     sangxxjin               Initial creation
+ */
+@Repository
+public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	public ProjectRepositoryImpl(EntityManager em) {
+		this.queryFactory = new JPAQueryFactory(em);
+	}
+
+	@Override
+	public Page<Project> findByFilters(Pageable pageable, List<Long> techStackIds, List<Long> devPositionIds,
+		String sort) {
+		JPAQuery<Project> query = buildQueryWithFilters(techStackIds, devPositionIds, sort);
+
+		List<Project> content = getQuerydslContent(query, pageable);
+		long totalElements = query.fetchCount();
+
+		return new PageImpl<>(content, pageable, totalElements);
+	}
+
+	private JPAQuery<Project> buildQueryWithFilters(List<Long> techStackIds, List<Long> devPositionIds, String sort) {
+		QProject project = QProject.project;
+		QProjectTechStack projectTechStack = QProjectTechStack.projectTechStack;
+		QProjectDevPosition projectDevPosition = QProjectDevPosition.projectDevPosition;
+		QLike like = QLike.like;
+
+		JPAQuery<Project> query = queryFactory.selectDistinct(project)
+			.from(project)
+			.join(project.projectTechStacks, projectTechStack)
+			.join(project.projectDevPositions, projectDevPosition)
+			.leftJoin(project.likes, like)
+			.where(project.isOpen.isTrue());
+
+		applyTechStackFilter(query, techStackIds, projectTechStack);
+		applyDevPositionFilter(query, devPositionIds, projectDevPosition);
+		applySort(query, sort, project, like);
+
+		return query;
+	}
+
+	private void applyTechStackFilter(JPAQuery<Project> query, List<Long> techStackIds,
+		QProjectTechStack projectTechStack) {
+		if (techStackIds != null && !techStackIds.isEmpty()) {
+			query.where(projectTechStack.techStack.id.in(techStackIds));
+		}
+	}
+
+	private void applyDevPositionFilter(JPAQuery<Project> query, List<Long> devPositionIds,
+		QProjectDevPosition projectDevPosition) {
+		if (devPositionIds != null && !devPositionIds.isEmpty()) {
+			query.where(projectDevPosition.developmentPosition.id.in(devPositionIds));
+		}
+	}
+
+	private void applySort(JPAQuery<Project> query, String sort, QProject project, QLike like) {
+		if ("createdAt".equals(sort)) {
+			query.orderBy(project.createdAt.desc());
+		} else if ("like".equals(sort)) {
+			query.leftJoin(project.likes, QLike.like)
+				.groupBy(project.id)
+				.orderBy(QLike.like.id.count().desc());
+		}
+	}
+
+	private List<Project> getQuerydslContent(JPAQuery<Project> query, Pageable pageable) {
+		return query.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+}
+

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
@@ -2,9 +2,7 @@ package ssammudan.cotree.model.project.project.repository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -15,14 +13,13 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import jakarta.persistence.EntityManager;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.model.common.like.entity.QLike;
-import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
 import ssammudan.cotree.model.project.devposition.entity.QProjectDevPosition;
 import ssammudan.cotree.model.project.membership.entity.QProjectMembership;
 import ssammudan.cotree.model.project.project.entity.Project;
 import ssammudan.cotree.model.project.project.entity.QProject;
+import ssammudan.cotree.model.project.project.helper.ProjectQueryHelper;
 import ssammudan.cotree.model.project.techstack.entity.QProjectTechStack;
 
 /**
@@ -40,10 +37,12 @@ import ssammudan.cotree.model.project.techstack.entity.QProjectTechStack;
 public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
+	private final ProjectQueryHelper projectQueryHelper;
 	private static final String SORT_BY_LIKE = "like";
 
-	public ProjectRepositoryImpl(EntityManager em) {
-		this.queryFactory = new JPAQueryFactory(em);
+	public ProjectRepositoryImpl(JPAQueryFactory queryFactory, ProjectQueryHelper projectQueryHelper) {
+		this.queryFactory = queryFactory;
+		this.projectQueryHelper = projectQueryHelper;
 	}
 
 	@Override
@@ -85,7 +84,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			return new PageImpl<>(Collections.emptyList(), pageable, 0);
 
 		List<Project> projects = fetchProjectsWithDetails(projectIds);
-		List<ProjectListResponse> content = convertToDtoOrdered(projects, projectIds);
+		List<ProjectListResponse> content = projectQueryHelper.convertToDtoOrdered(projects, projectIds);
 
 		Long total = queryFactory.select(QProject.project.countDistinct())
 			.from(QProject.project)
@@ -102,13 +101,13 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			return Collections.emptyList();
 
 		List<Project> projects = fetchProjectsWithDetails(projectIds);
-		return convertToDtoOrdered(projects, projectIds);
+		return projectQueryHelper.convertToDtoOrdered(projects, projectIds);
 	}
 
 	@Override
 	public Page<ProjectListResponse> findByFilters(Pageable pageable, List<Long> techStackIds,
 		List<Long> devPositionIds, String sort) {
-		BooleanBuilder where = buildFilterConditions(techStackIds, devPositionIds);
+		BooleanBuilder where = projectQueryHelper.buildFilterConditions(techStackIds, devPositionIds);
 
 		List<Long> filteredProjectIds = queryFactory
 			.select(QProject.project.id)
@@ -130,12 +129,12 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 		if (filteredProjectIds.isEmpty())
 			return new PageImpl<>(Collections.emptyList(), pageable, 0);
 
-		List<Long> sortedIds = sortFilteredProjects(filteredProjectIds, sort, pageable);
+		List<Long> sortedIds = projectQueryHelper.sortFilteredProjects(filteredProjectIds, sort, pageable);
 		if (sortedIds.isEmpty())
 			return new PageImpl<>(Collections.emptyList(), pageable, 0);
 
 		List<Project> projects = fetchProjectsWithDetails(sortedIds);
-		List<ProjectListResponse> content = convertToDtoOrdered(projects, sortedIds);
+		List<ProjectListResponse> content = projectQueryHelper.convertToDtoOrdered(projects, sortedIds);
 
 		return new PageImpl<>(content, pageable, filteredProjectIds.size());
 	}
@@ -177,73 +176,6 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			.leftJoin(QProject.project.member).fetchJoin()
 			.where(QProject.project.id.in(ids))
 			.distinct()
-			.fetch();
-	}
-
-	private List<ProjectListResponse> convertToDtoOrdered(List<Project> projects, List<Long> orderedIds) {
-		Map<Long, ProjectListResponse> projectDtoMap = projects.stream()
-			.collect(Collectors.toMap(Project::getId, this::toDto));
-
-		return orderedIds.stream()
-			.map(projectDtoMap::get)
-			.toList();
-	}
-
-	private ProjectListResponse toDto(Project p) {
-		List<String> techStacksImageUrl = p.getProjectTechStacks().stream()
-			.map(ts -> ts.getTechStack().getImageUrl())
-			.toList();
-
-		long likeCount = p.getLikes().size();
-		int recruitmentCount = p.getProjectDevPositions().stream()
-			.mapToInt(ProjectDevPosition::getAmount).sum();
-
-		String description = p.getDescription();
-		if (description.length() > 30) {
-			description = description.substring(0, 30) + "...";
-		}
-
-		return new ProjectListResponse(
-			p.getId(),
-			p.getTitle(),
-			description,
-			p.getProjectImageUrl(),
-			p.getViewCount(),
-			likeCount,
-			recruitmentCount,
-			p.getIsOpen(),
-			p.getStartDate(),
-			p.getEndDate(),
-			techStacksImageUrl,
-			p.getMember().getUsername(),
-			p.getMember().getProfileImageUrl()
-		);
-	}
-
-	private BooleanBuilder buildFilterConditions(List<Long> techStackIds, List<Long> devPositionIds) {
-		BooleanBuilder where = new BooleanBuilder();
-		if (techStackIds != null && !techStackIds.isEmpty()) {
-			where.and(QProjectTechStack.projectTechStack.techStack.id.in(techStackIds));
-		}
-		if (devPositionIds != null && !devPositionIds.isEmpty()) {
-			where.and(QProjectDevPosition.projectDevPosition.developmentPosition.id.in(devPositionIds));
-		}
-		return where;
-	}
-
-	private List<Long> sortFilteredProjects(List<Long> ids, String sort, Pageable pageable) {
-		return queryFactory.select(QProject.project.id)
-			.from(QProject.project)
-			.leftJoin(QProject.project.likes, QLike.like)
-			.where(QProject.project.id.in(ids))
-			.groupBy(QProject.project.id)
-			.orderBy(
-				SORT_BY_LIKE.equalsIgnoreCase(sort)
-					? QLike.like.id.count().desc()
-					: QProject.project.createdAt.desc()
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
 			.fetch();
 	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#116 
  <br/>

## 🔎 작업 내용
- 프로젝트 조회 api queryDSL 구현
- Hot Project 정렬 기준을 조회수, 좋아요 수 기준으로 변경
- 기술스택, 모집직무 정렬을 ID 기준 오름차순으로 고정
- queryDSL 헬퍼 클래스 구현

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- DTO 변환을 목록 조회는 QueryDSL에서, 상세 조회는 Service에서 진행했는데, 이 방식이 괜찮은지 궁금합니다.
  - 의도한 내용은 상세 조회의 경우 회원의 좋아요 여부, 작성자 여부 등 추가적인 로직이 필요하여 Service 단에서 Entity를 가져와 처리하도록 구현했습니다.
  <br/>