### PR TITLE
[FEAT] : #CB-1 커뮤니티 글 작성 대표 이미지 자동 추출 기능 추가

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
@@ -2,6 +2,9 @@ package ssammudan.cotree.domain.community.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+
 /**
  * PackageName : ssammudan.cotree.domain.community.dto
  * FileName    : CommunityResponse
@@ -12,15 +15,33 @@ import java.time.LocalDateTime;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-31     Baekgwa               Initial creation
+ * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
  */
 public class CommunityResponse {
 
 	private CommunityResponse() {
 	}
 
+	@Builder(access = AccessLevel.PRIVATE)
 	public record BoardListDetail(Long id, String title, String author, LocalDateTime createdAt, String content,
-								  Long commentCount, Long likeCount, Integer viewCount, String imageUrl, Boolean isLike,
-								  Boolean isNew) {
+								  Long commentCount, Long likeCount, Integer viewCount, String imageUrl,
+								  Boolean isLike, Boolean isNew) {
+
+		public static BoardListDetail modifyContent(BoardListDetail original, String newContent) {
+			return BoardListDetail.builder()
+				.id(original.id())
+				.title(original.title())
+				.author(original.author())
+				.createdAt(original.createdAt())
+				.content(newContent)
+				.commentCount(original.commentCount())
+				.likeCount(original.likeCount())
+				.viewCount(original.viewCount())
+				.imageUrl(original.imageUrl())
+				.isLike(original.isLike())
+				.isNew(original.isNew())
+				.build();
+		}
 	}
 
 	public record BoardDetail(String title, String author, LocalDateTime createdAt, String content, Long likeCount,

--- a/src/main/java/ssammudan/cotree/model/community/community/entity/Community.java
+++ b/src/main/java/ssammudan/cotree/model/community/community/entity/Community.java
@@ -56,30 +56,36 @@ public class Community extends BaseEntity {
 	@Column(name = "view_count", nullable = false)
 	private Integer viewCount;
 
+	@Column(name = "thumbnail_image", columnDefinition = "TEXT")
+	private String thumbnailImage;
+
 	@Builder(access = AccessLevel.PRIVATE)
 	private Community(CommunityCategory communityCategory, Member member, String title, String content,
-			Integer viewCount) {
+		Integer viewCount, String thumbnailImage) {
 		this.communityCategory = communityCategory;
 		this.member = member;
 		this.title = title;
 		this.content = content;
 		this.viewCount = viewCount;
+		this.thumbnailImage = thumbnailImage;
 	}
 
 	public static Community createNewCommunityBoard(
-			CommunityCategory communityCategory,
-			Member member,
-			String title,
-			String content
+		CommunityCategory communityCategory,
+		Member member,
+		String title,
+		String content,
+		String thumbnailImage
 	) {
 		return Community
-				.builder()
-				.communityCategory(communityCategory)
-				.member(member)
-				.title(title)
-				.content(content)
-				.viewCount(0)
-				.build();
+			.builder()
+			.communityCategory(communityCategory)
+			.member(member)
+			.title(title)
+			.content(content)
+			.viewCount(0)
+			.thumbnailImage(thumbnailImage)
+			.build();
 	}
 
 	public void modifyCommunity(final String title, final String content) {

--- a/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
@@ -38,6 +38,7 @@ import ssammudan.cotree.model.member.member.entity.QMember;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-04-01     Baekgwa               Initial creation
+ * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
  */
 @Repository
 @RequiredArgsConstructor
@@ -79,7 +80,7 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
 					.from(like)
 					.where(like.community.id.eq(community.id)),
 				community.viewCount,
-				community.title,     // todo : 대표 이미지 그냥 필드로 가지고 있는게 간단할듯
+				community.thumbnailImage,
 				memberId != null ? JPAExpressions
 					.select(like.count())
 					.from(like)

--- a/src/main/resources/db/migration/V2.2__add_column_community_thumbnail_image.sql
+++ b/src/main/resources/db/migration/V2.2__add_column_community_thumbnail_image.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community
+    ADD COLUMN thumbnail_image text;

--- a/src/test/java/ssammudan/cotree/integration/factory/CommunityDataFactory.java
+++ b/src/test/java/ssammudan/cotree/integration/factory/CommunityDataFactory.java
@@ -55,7 +55,7 @@ public class CommunityDataFactory {
 	 * 총 생성되는 수 : MemberList * CommunityCategory * count
 	 */
 	public List<Community> createAndSaveCommunity(List<Member> memberList,
-			List<CommunityCategory> communityCategoryList, final int count) {
+		List<CommunityCategory> communityCategoryList, final int count) {
 
 		if (count == 0) {
 			return List.of();
@@ -67,11 +67,12 @@ public class CommunityDataFactory {
 			for (Member member : memberList) {
 				for (CommunityCategory category : communityCategoryList) {
 					communityList.add(
-							Community.createNewCommunityBoard(
-									category,
-									member,
-									String.format("[%s카테고리]제목:%s멤버", category.getName(), member.getId()),
-									String.format("내용입니다. %s 카테고리 %s멤버의 글 입니다.", category.getName(), member.getId())));
+						Community.createNewCommunityBoard(
+							category,
+							member,
+							String.format("[%s카테고리]제목:%s멤버", category.getName(), member.getId()),
+							String.format("내용입니다. %s 카테고리 %s멤버의 글 입니다.", category.getName(), member.getId()),
+							null));
 				}
 			}
 		}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#23 
  <br/>

## 🔎 작업 내용
- 글 작성 시, 썸네일 이미지 추출하도록 추가하였습니다.
  - 상세 조회시에도 썸네일이 필요하기 때문에, 썸네일 이미지용 컬럼을 하나 table 에 추가하였습니다.
- 글 목록 조회 시, 이미지는 제거 후, 출력되도록 서비스 로직을 추가하였습니다.
  - 리스트 조회 시, 이미지는 따로 보여줄 필요가 없기때문에 삭제하였습니다.
![image](https://github.com/user-attachments/assets/82b74fc0-cbe0-4dbe-a482-4ad8875631f0)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- 기존 record 형 response 객체에 content 를 수정하게 하였더니, 불변성에 의해서 새로운 BoardListDetail 를 생성하는 정적 팩터리 메서드가 생겼습니다...
  - 사실 이렇게 되면 content 에 대해서는 불변성을 지킬 필요가 없으니, record 객체에서 일반 class 로 변경하고 content 제외 나머지 필드에 대해서 final 로 불변성을 보장하는게 더 나은방향일지 고민이 됩니다.
- 
  <br/>

## 📈이미지 첨부 (필요시)
  <br/>