### PR TITLE
[REFACTOR] Community Board 조회 (리스트, 단건) 시, 프로필 이미지 추가 return

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
@@ -17,6 +17,7 @@ import lombok.With;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-31     Baekgwa               Initial creation
  * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
+ * 2025-04-08     Baekgwa               목록, 상세 조회 시, 작성자의 프로필 이미지 return 추가
  */
 public class CommunityResponse {
 
@@ -31,7 +32,7 @@ public class CommunityResponse {
 	}
 
 	public record BoardDetail(String title, String author, LocalDateTime createdAt, String content, Long likeCount,
-							  Integer viewCount, Boolean isLike, Boolean isOwner) {
+							  Integer viewCount, Boolean isLike, Boolean isOwner, String profileImage) {
 	}
 
 	public record BoardModify(Long boardId) {

--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.With;
 
 /**
  * PackageName : ssammudan.cotree.domain.community.dto
@@ -22,26 +23,11 @@ public class CommunityResponse {
 	private CommunityResponse() {
 	}
 
+	@With
 	@Builder(access = AccessLevel.PRIVATE)
 	public record BoardListDetail(Long id, String title, String author, LocalDateTime createdAt, String content,
 								  Long commentCount, Long likeCount, Integer viewCount, String imageUrl,
-								  Boolean isLike, Boolean isNew) {
-
-		public static BoardListDetail modifyContent(BoardListDetail original, String newContent) {
-			return BoardListDetail.builder()
-				.id(original.id())
-				.title(original.title())
-				.author(original.author())
-				.createdAt(original.createdAt())
-				.content(newContent)
-				.commentCount(original.commentCount())
-				.likeCount(original.likeCount())
-				.viewCount(original.viewCount())
-				.imageUrl(original.imageUrl())
-				.isLike(original.isLike())
-				.isNew(original.isNew())
-				.build();
-		}
+								  Boolean isLike, Boolean isNew, String profileImage) {
 	}
 
 	public record BoardDetail(String title, String author, LocalDateTime createdAt, String content, Long likeCount,

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
@@ -115,10 +115,7 @@ public class CommunityServiceImpl implements CommunityService {
 		// Content 내용 후처리
 		// 마크다운 이미지 형식 + 불필요한 띄워쓰기 공백 삭제 처리.
 		List<CommunityResponse.BoardListDetail> processedList = findBoardList.getContent().stream()
-			.map(board -> {
-				String processedContent = processMarkdownContent(board.content());
-				return CommunityResponse.BoardListDetail.modifyContent(board, processedContent);
-			})
+			.map(board -> board.withContent(processMarkdownContent(board.content())))
 			.toList();
 
 		// 새로운 페이지 Response 객체 생성

--- a/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
@@ -135,7 +135,8 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
 					Ops.EQ,
 					community.member.id,
 					Expressions.constant(memberId)
-				) : Expressions.constant(Boolean.FALSE)
+				) : Expressions.constant(Boolean.FALSE),
+				member.profileImageUrl
 			))
 			.from(community)
 			.join(member).on(community.member.id.eq(member.id))

--- a/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/community/community/repository/CommunityRepositoryImpl.java
@@ -88,7 +88,8 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
 						.and(like.member.id.eq(memberId)))
 					.exists()
 					: Expressions.constant(Boolean.FALSE),
-				Expressions.booleanTemplate("{0} >= {1}", community.createdAt, oneDayAgo)
+				Expressions.booleanTemplate("{0} >= {1}", community.createdAt, oneDayAgo),
+				member.profileImageUrl
 			))
 			.from(community)
 			.join(member).on(community.member.id.eq(member.id))


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#133 
  <br/>

## 🔎 작업 내용
- FE 요청사항으로, community 조회 시, 작성자의 이미지url 을 같이 return 하도록 추가하였습니다.
- record 객체 내부 데이터를 바꾸기 위해, 정적 팩터리 메서드로 새 인스턴스를 생성하던 로직을 `with` 사용으로 변경하였습니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- N/A

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>