### PR TITLE
[FEAT] : #CC-1 커뮤니티 카테고리 조회 기능 추가 구현 및 작성 리팩토링

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/category/controller/CategoryController.java
+++ b/src/main/java/ssammudan/cotree/domain/category/controller/CategoryController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.category.dto.CommunityCategoryResponse;
 import ssammudan.cotree.domain.category.dto.EducationCategoryResponse;
 import ssammudan.cotree.domain.category.dto.PositionResponse;
 import ssammudan.cotree.domain.category.dto.TechStackResponse;
@@ -27,6 +28,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     kwak               Initial creation
  * 2025. 4. 7.     Baekgwa            교육 카테고리 조회 추가
+ * 2025. 4. 8.     Baekgwa            커뮤니티 글 카테고리 조회 추가
  */
 @RestController
 @RequiredArgsConstructor
@@ -51,6 +53,14 @@ public class CategoryController {
 	@GetMapping("/education")
 	@Operation(summary = "교육 카테고리 전체 조회", description = "교육 카테고리를 전체 조회합니다.")
 	public BaseResponse<List<EducationCategoryResponse>> findEducationCategoryList() {
-		return BaseResponse.success(SuccessCode.EDUCATION_CATEGORY_FIND_SUCCESS, categoryService.findEducationCategoryList());
+		return BaseResponse.success(SuccessCode.EDUCATION_CATEGORY_FIND_SUCCESS,
+			categoryService.findEducationCategoryList());
+	}
+
+	@GetMapping("/community")
+	@Operation(summary = "커뮤니티 글 카테고리 전체 조회", description = "커뮤니티의 글의 전체 카테고리를 조회 합니다.")
+	public BaseResponse<List<CommunityCategoryResponse>> findCommunityCategoryList() {
+		return BaseResponse.success(SuccessCode.COMMUNITY_CATEGORY_FIND_SUCCESS,
+			categoryService.findCommunityCategoryList());
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/category/dto/CommunityCategoryResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/category/dto/CommunityCategoryResponse.java
@@ -1,0 +1,30 @@
+package ssammudan.cotree.domain.category.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import ssammudan.cotree.model.community.category.entity.CommunityCategory;
+
+/**
+ * PackageName : ssammudan.cotree.domain.category.dto
+ * FileName    : CommunityCategoryResponse
+ * Author      : Baekgwa
+ * Date        : 2025-04-08
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-08     Baekgwa               Initial creation
+ */
+@Builder(access = AccessLevel.PRIVATE)
+public record CommunityCategoryResponse(
+	Long id,
+	String name
+) {
+	public static CommunityCategoryResponse of(CommunityCategory category) {
+		return CommunityCategoryResponse
+			.builder()
+			.id(category.getId())
+			.name(category.getName())
+			.build();
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/category/service/CategoryService.java
+++ b/src/main/java/ssammudan/cotree/domain/category/service/CategoryService.java
@@ -2,6 +2,7 @@ package ssammudan.cotree.domain.category.service;
 
 import java.util.List;
 
+import ssammudan.cotree.domain.category.dto.CommunityCategoryResponse;
 import ssammudan.cotree.domain.category.dto.EducationCategoryResponse;
 import ssammudan.cotree.domain.category.dto.PositionResponse;
 import ssammudan.cotree.domain.category.dto.TechStackResponse;
@@ -17,6 +18,7 @@ import ssammudan.cotree.domain.category.dto.TechStackResponse;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     kwak               Initial creation
  * 2025. 4. 7.     Baekgwa            교육 카테고리 조회 추가
+ * 2025. 4. 8.     Baekgwa            커뮤니티 글 카테고리 조회 추가
  */
 public interface CategoryService {
 
@@ -25,4 +27,6 @@ public interface CategoryService {
 	List<PositionResponse> findPositions();
 
 	List<EducationCategoryResponse> findEducationCategoryList();
+
+	List<CommunityCategoryResponse> findCommunityCategoryList();
 }

--- a/src/main/java/ssammudan/cotree/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/category/service/CategoryServiceImpl.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.category.dto.CommunityCategoryResponse;
 import ssammudan.cotree.domain.category.dto.EducationCategoryResponse;
 import ssammudan.cotree.domain.category.dto.PositionResponse;
 import ssammudan.cotree.domain.category.dto.TechStackResponse;
 import ssammudan.cotree.model.common.developmentposition.repository.DevelopmentPositionRepository;
 import ssammudan.cotree.model.common.techstack.repository.TechStackRepository;
+import ssammudan.cotree.model.community.category.repository.CommunityCategoryRepository;
 import ssammudan.cotree.model.education.category.repository.EducationCategoryRepository;
 
 /**
@@ -25,6 +27,7 @@ import ssammudan.cotree.model.education.category.repository.EducationCategoryRep
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 4. 2.     kwak               Initial creation
  * 2025. 4. 7.     Baekgwa            교육 카테고리 조회 추가
+ * 2025. 4. 8.     Baekgwa            커뮤니티 글 카테고리 조회 추가
  */
 @Service
 @RequiredArgsConstructor
@@ -33,6 +36,7 @@ public class CategoryServiceImpl implements CategoryService {
 	private final TechStackRepository techStackRepository;
 	private final DevelopmentPositionRepository developmentPositionRepository;
 	private final EducationCategoryRepository educationCategoryRepository;
+	private final CommunityCategoryRepository communityCategoryRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -45,7 +49,7 @@ public class CategoryServiceImpl implements CategoryService {
 	}
 
 	@Override
-	@Transactional
+	@Transactional(readOnly = true)
 	public List<PositionResponse> findPositions() {
 		return developmentPositionRepository.findAll().stream()
 			.map(developmentPosition ->
@@ -54,11 +58,21 @@ public class CategoryServiceImpl implements CategoryService {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
 	@Override
 	public List<EducationCategoryResponse> findEducationCategoryList() {
 		return educationCategoryRepository.findAll()
 			.stream().map(EducationCategoryResponse::of)
 			.sorted(Comparator.comparing(EducationCategoryResponse::id))
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public List<CommunityCategoryResponse> findCommunityCategoryList() {
+		return communityCategoryRepository.findAll()
+			.stream().map(CommunityCategoryResponse::of)
+			.sorted(Comparator.comparing(CommunityCategoryResponse::id))
 			.toList();
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityRequest.java
@@ -1,6 +1,5 @@
 package ssammudan.cotree.domain.community.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +16,7 @@ import ssammudan.cotree.domain.community.dto.valid.CommunityTitle;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-28     Baekgwa               Initial creation
+ * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
  */
 public class CommunityRequest {
 
@@ -26,8 +26,7 @@ public class CommunityRequest {
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class CreateBoard {
-		@NotBlank(message = "글 카테고리는 필수값 입니다.")
-		private String category;
+		private Long communityCategoryId;
 
 		@CommunityTitle
 		private String title;
@@ -35,8 +34,8 @@ public class CommunityRequest {
 		@CommunityContent
 		private String content;
 
-		public CreateBoard(String category, String title, String content) {
-			this.category = category;
+		public CreateBoard(Long communityCategoryId, String title, String content) {
+			this.communityCategoryId = communityCategoryId;
 			this.title = title;
 			this.content = content;
 		}

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
@@ -37,6 +37,7 @@ import ssammudan.cotree.model.member.member.repository.MemberRepository;
  * 2025-03-28     Baekgwa               Initial creation
  * 2025-04-04     Baekgwa               글 수정/삭제 기능 추가
  * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
+ * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
  */
 @Service
 @RequiredArgsConstructor
@@ -51,7 +52,7 @@ public class CommunityServiceImpl implements CommunityService {
 	public CommunityResponse.BoardCreate createNewBoard(
 		final CommunityRequest.CreateBoard createBoard, final String userId) {
 		// 카테고리 조회 및 유효성 확인
-		CommunityCategory findCommunityCategory = communityCategoryRepository.findByName(createBoard.getCategory())
+		CommunityCategory findCommunityCategory = communityCategoryRepository.findById(createBoard.getCommunityCategoryId())
 			.orElseThrow(() -> new GlobalException(ErrorCode.COMMUNITY_BOARD_CATEGORY_INVALID));
 
 		// userId 로 회원 정보 검색

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -67,6 +67,7 @@ public enum SuccessCode {
 	//Common: 9001 ~ 9999
 	TECH_STACK_FIND_SUCCESS(HttpStatus.OK, "200", "기술 스택 조회 성공"),
 	EDUCATION_CATEGORY_FIND_SUCCESS(HttpStatus.OK, "200", "교육 카테고리 조회 성공"),
+	COMMUNITY_CATEGORY_FIND_SUCCESS(HttpStatus.OK, "200", "커뮤니티 글 카테고리 조회 성공"),
 	POSITION_FIND_SUCCESS(HttpStatus.OK, "200", "개발 직무 조회 성공");
 
 	private final HttpStatus status;

--- a/src/test/java/ssammudan/cotree/domain/community/dto/CommunityRequestTest.java
+++ b/src/test/java/ssammudan/cotree/domain/community/dto/CommunityRequestTest.java
@@ -24,6 +24,7 @@ import jakarta.validation.ValidatorFactory;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-31     Baekgwa               Initial creation
+ * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
  */
 class CommunityRequestTest {
 
@@ -47,13 +48,13 @@ class CommunityRequestTest {
 	@Test
 	void createBoard1() {
 		// given
-		CommunityRequest.CreateBoard createBoard = new CommunityRequest.CreateBoard("코드리뷰", "제목", "내용");
+		CommunityRequest.CreateBoard createBoard = new CommunityRequest.CreateBoard(2L, "제목", "내용");
 
 		// when
 		Set<ConstraintViolation<CommunityRequest.CreateBoard>> validate = validator.validate(createBoard);
 
 		// then
-		assertThat(validate).hasSize(0);
+		assertThat(validate).isEmpty();
 	}
 
 	@DisplayName("커뮤니티 새글 작성 시, 잘못된 데이터 검증")
@@ -62,18 +63,16 @@ class CommunityRequestTest {
 		// given
 		String tooLongTitle = "A".repeat(51);
 		String tooLongContent = "B".repeat(1001);
-		CommunityRequest.CreateBoard createBoard = new CommunityRequest.CreateBoard("", tooLongTitle, tooLongContent);
+		CommunityRequest.CreateBoard createBoard = new CommunityRequest.CreateBoard(0L, tooLongTitle, tooLongContent);
 
 		// when
 		Set<ConstraintViolation<CommunityRequest.CreateBoard>> validate = validator.validate(createBoard);
 
 		// then
-		assertThat(validate).hasSize(3);
+		assertThat(validate).hasSize(2);
 		assertThat(validate.stream()
-				.anyMatch(v -> v.getMessage().equals("글 카테고리는 필수값 입니다."))).isTrue();
+			.anyMatch(v -> v.getMessage().equals("제목은 1자 이상 50자 이하로 입력해주세요."))).isTrue();
 		assertThat(validate.stream()
-				.anyMatch(v -> v.getMessage().equals("제목은 1자 이상 50자 이하로 입력해주세요."))).isTrue();
-		assertThat(validate.stream()
-				.anyMatch(v -> v.getMessage().equals("내용은 1자 이상 1000자 이하로 입력해주세요."))).isTrue();
+			.anyMatch(v -> v.getMessage().equals("내용은 1자 이상 1000자 이하로 입력해주세요."))).isTrue();
 	}
 }

--- a/src/test/java/ssammudan/cotree/domain/community/service/CommunityServiceImplTest.java
+++ b/src/test/java/ssammudan/cotree/domain/community/service/CommunityServiceImplTest.java
@@ -26,6 +26,7 @@ import ssammudan.cotree.model.member.member.entity.Member;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-31     Baekgwa               Initial creation
+ * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
  */
 @Transactional
 class CommunityServiceImplTest extends SpringBootTestSupporter {
@@ -36,29 +37,29 @@ class CommunityServiceImplTest extends SpringBootTestSupporter {
 		// given
 		List<CommunityCategory> savedCommunityCategoryList = communityFactory.createAndSaveCommunityCategory(10);
 		CommunityCategory savedCommunityCategory = savedCommunityCategoryList.getFirst();
-		String communityCategoryName = savedCommunityCategory.getName();
+		Long communityCategoryId = savedCommunityCategory.getId();
 
 		String newTitle = "새글 제목";
 		String newContent = """
-				# 새글 제목
+			# 새글 제목
 
-				이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
+			이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
 
-				## 주요 내용
-				- 첫 번째 리스트 아이템
-				- 두 번째 리스트 아이템
-				- 세 번째 리스트 아이템
+			## 주요 내용
+			- 첫 번째 리스트 아이템
+			- 두 번째 리스트 아이템
+			- 세 번째 리스트 아이템
 
-				### 코드 블록
-				```java
-				public static void main(String[] args) {
-				    System.out.println("Hello, Markdown!");
-				}
-				```
-				""";
+			### 코드 블록
+			```java
+			public static void main(String[] args) {
+			    System.out.println("Hello, Markdown!");
+			}
+			```
+			""";
 
 		CommunityRequest.CreateBoard createBoard =
-				new CommunityRequest.CreateBoard(communityCategoryName, newTitle, newContent);
+			new CommunityRequest.CreateBoard(communityCategoryId, newTitle, newContent);
 
 		List<Member> savedMemberList = memberDataFactory.createAndSaveMember(10);
 		Member savedMember = savedMemberList.getFirst();
@@ -73,8 +74,8 @@ class CommunityServiceImplTest extends SpringBootTestSupporter {
 		assertThat(findList).hasSize(1);
 		Community findData = findList.getFirst();
 		assertThat(findData)
-				.extracting("title", "content", "viewCount")
-				.containsExactly(newTitle, newContent, 0);
+			.extracting("title", "content", "viewCount")
+			.containsExactly(newTitle, newContent, 0);
 	}
 
 	@DisplayName("커뮤니티 새글 작성. 등록된 커뮤니티 카테고리가 아니라면, 오류를 발생한다.")
@@ -83,36 +84,36 @@ class CommunityServiceImplTest extends SpringBootTestSupporter {
 		// given
 		String newTitle = "새글 제목";
 		String newContent = """
-				# 새글 제목
+			# 새글 제목
 
-				이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
+			이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
 
-				## 주요 내용
-				- 첫 번째 리스트 아이템
-				- 두 번째 리스트 아이템
-				- 세 번째 리스트 아이템
+			## 주요 내용
+			- 첫 번째 리스트 아이템
+			- 두 번째 리스트 아이템
+			- 세 번째 리스트 아이템
 
-				### 코드 블록
-				```java
-				public static void main(String[] args) {
-				    System.out.println("Hello, Markdown!");
-				}
-				```
-				""";
+			### 코드 블록
+			```java
+			public static void main(String[] args) {
+			    System.out.println("Hello, Markdown!");
+			}
+			```
+			""";
 
 		CommunityRequest.CreateBoard createBoard =
-				new CommunityRequest.CreateBoard("Unknown Category", newTitle, newContent);
+			new CommunityRequest.CreateBoard(0L, newTitle, newContent);
 
 		List<Member> savedMemberList = memberDataFactory.createAndSaveMember(10);
-		Member savedMember = savedMemberList.getFirst();
+		String memberId = savedMemberList.getFirst().getId();
 		em.flush();
 		em.clear();
 
 		// when // then
-		assertThatThrownBy(() -> communityService.createNewBoard(createBoard, savedMember.getId()))
-				.isInstanceOf(GlobalException.class)
-				.extracting("errorCode")
-				.isEqualTo(ErrorCode.COMMUNITY_BOARD_CATEGORY_INVALID);
+		assertThatThrownBy(() -> communityService.createNewBoard(createBoard, memberId))
+			.isInstanceOf(GlobalException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.COMMUNITY_BOARD_CATEGORY_INVALID);
 	}
 
 	@DisplayName("커뮤니티 새글 작성. 로그인 아이디 정보가 이상하다면, 오류를 발생한다.")
@@ -121,37 +122,37 @@ class CommunityServiceImplTest extends SpringBootTestSupporter {
 		// given
 		List<CommunityCategory> savedCommunityCategoryList = communityFactory.createAndSaveCommunityCategory(10);
 		CommunityCategory savedCommunityCategory = savedCommunityCategoryList.getFirst();
-		String communityCategoryName = savedCommunityCategory.getName();
+		Long communityCategoryId = savedCommunityCategory.getId();
 
 		String newTitle = "새글 제목";
 		String newContent = """
-				# 새글 제목
+			# 새글 제목
 
-				이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
+			이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
 
-				## 주요 내용
-				- 첫 번째 리스트 아이템
-				- 두 번째 리스트 아이템
-				- 세 번째 리스트 아이템
+			## 주요 내용
+			- 첫 번째 리스트 아이템
+			- 두 번째 리스트 아이템
+			- 세 번째 리스트 아이템
 
-				### 코드 블록
-				```java
-				public static void main(String[] args) {
-				    System.out.println("Hello, Markdown!");
-				}
-				```
-				""";
+			### 코드 블록
+			```java
+			public static void main(String[] args) {
+			    System.out.println("Hello, Markdown!");
+			}
+			```
+			""";
 
 		CommunityRequest.CreateBoard createBoard =
-				new CommunityRequest.CreateBoard(communityCategoryName, newTitle, newContent);
+			new CommunityRequest.CreateBoard(communityCategoryId, newTitle, newContent);
 
 		em.flush();
 		em.clear();
 
 		// when // then
 		assertThatThrownBy(() -> communityService.createNewBoard(createBoard, "Unknown Member Id"))
-				.isInstanceOf(GlobalException.class)
-				.extracting("errorCode")
-				.isEqualTo(ErrorCode.COMMUNITY_MEMBER_NOTFOUND);
+			.isInstanceOf(GlobalException.class)
+			.extracting("errorCode")
+			.isEqualTo(ErrorCode.COMMUNITY_MEMBER_NOTFOUND);
 	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#142 
  <br/>

## 🔎 작업 내용
- 커뮤니티 글 카테고리 조회 기능 추가되었습니다. (리스트 조회 형식)
- 글 작성 시, request body 값이 변경되었습니다.
  - 기존 : request body 內 community category 를 String 값으로 전달
  - 변경 : communityCategoryId 로 전달
- 기타, 줄바꿈 컨벤션 안맞는 것 수정 (예전에 작성된 테스트 코드)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>