### PR TITLE
[Bug] : 회원 업데이트 버그 수정

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/member/controller/MemberController.java
+++ b/src/main/java/ssammudan/cotree/domain/member/controller/MemberController.java
@@ -64,8 +64,7 @@ public class MemberController {
 		@AuthenticationPrincipal CustomUser customUser
 	) {
 		String memberId = customUser.getId();
-		Member member = memberService.findById(memberId);
-		memberService.updateMember(member, request);
+		memberService.updateMember(memberId, request);
 
 		return BaseResponse.success(SuccessCode.MEMBER_INFO_UPDATE_SUCCESS);
 	}
@@ -102,7 +101,7 @@ public class MemberController {
 	public BaseResponse<Void> signOut(HttpServletRequest request, HttpServletResponse response) {
 		String refreshToken = getValueInCookie("refresh_token", request);
 		long remainingTime = refreshTokenService.getClaimsFromToken(refreshToken)
-								 .getExpiration().getTime() - new Date().getTime();
+			.getExpiration().getTime() - new Date().getTime();
 
 		tokenBlacklistService.addToBlacklist(refreshToken, remainingTime);
 

--- a/src/main/java/ssammudan/cotree/domain/member/dto/info/MemberInfoResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/member/dto/info/MemberInfoResponse.java
@@ -18,11 +18,12 @@ import ssammudan.cotree.model.member.member.type.MemberRole;
  */
 public record MemberInfoResponse(
 	String email,
+	String username,
 	String nickname,
 	MemberRole role,
 	LocalDateTime createdAt
 ) {
 	public MemberInfoResponse(Member member) {
-		this(member.getEmail(), member.getNickname(), member.getRole(), member.getCreatedAt());
+		this(member.getEmail(), member.getUsername(), member.getNickname(), member.getRole(), member.getCreatedAt());
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/member/service/MemberService.java
+++ b/src/main/java/ssammudan/cotree/domain/member/service/MemberService.java
@@ -11,7 +11,7 @@ public interface MemberService {
 
 	Member signIn(MemberSigninRequest request);
 
-	Member updateMember(Member memberId, MemberInfoRequest request);
+	Member updateMember(String memberId, MemberInfoRequest request);
 
 	Member findById(String memberId);
 

--- a/src/main/java/ssammudan/cotree/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/member/service/MemberServiceImpl.java
@@ -71,7 +71,10 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	@Transactional
-	public Member updateMember(Member member, MemberInfoRequest memberInfoRequest) {
+	public Member updateMember(String memberId, MemberInfoRequest memberInfoRequest) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+
 		return member.update(memberInfoRequest);
 	}
 

--- a/src/main/java/ssammudan/cotree/model/member/member/entity/Member.java
+++ b/src/main/java/ssammudan/cotree/model/member/member/entity/Member.java
@@ -73,8 +73,8 @@ public class Member extends BaseEntity {
 	}
 
 	public Member update(MemberInfoRequest request) {
-		this.nickname = request.username();
-		this.phoneNumber = request.nickname();
+		this.username = request.username();
+		this.nickname = request.nickname();
 		this.profileImageUrl = request.profileImageUrl();
 		return this;
 	}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
- 회원 업데이트(PUT)시에 DTO와 Entity의 필드값이 잘못 매핑되어 수정이 의도하지 않은 형태로 이루어지는 버그가 발생했습니다.
- 해당 부분을 수정하고 프론트엔드의 요구사항을 반영하여 회원 조회 시 nickname 뿐만 아니라 username도 추가하여 반환하도록 수정하였습니다.
  <br/>

## 🔎 작업 내용
- 업데이트 로직에서 잘못된 부분 수정했습니다~
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>