### PR TITLE
[Refactor] TechBook, 수강평(리뷰) 응답 객체 수정 등

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/controller/TechBookController.java
@@ -51,13 +51,8 @@ public class TechBookController {
 		@PathVariable @Min(1) Long id,
 		@Nullable @AuthenticationPrincipal final UserDetails userDetails
 	) {
-		TechBookResponse.Detail responseDto;
-		if (userDetails != null) {
-			String memberId = ((CustomUser)userDetails).getId();
-			responseDto = techBookService.findTechBookById(id, memberId);
-		} else {
-			responseDto = techBookService.findTechBookById(id);
-		}
+		String memberId = (userDetails != null) ? ((CustomUser)userDetails).getId() : null;
+		TechBookResponse.Detail responseDto = techBookService.findTechBookById(id, memberId);
 		return BaseResponse.success(SuccessCode.TECH_BOOK_READ_SUCCESS, responseDto);
 	}
 
@@ -68,10 +63,13 @@ public class TechBookController {
 		@RequestParam(required = false) String keyword,
 		@RequestParam(value = "page", required = false, defaultValue = "0") final int page,
 		@RequestParam(value = "size", required = false, defaultValue = "16") final int size,
-		@RequestParam(value = "sort", required = false, defaultValue = "LATEST") final SearchEducationSort sort
+		@RequestParam(value = "sort", required = false, defaultValue = "LATEST") final SearchEducationSort sort,
+		@RequestParam(value = "categoryId", required = false) final Long educationId,
+		@Nullable @AuthenticationPrincipal final UserDetails userDetails
 	) {
+		String memberId = (userDetails != null) ? ((CustomUser)userDetails).getId() : null;
 		PageResponse<TechBookResponse.ListInfo> responseDto = techBookService.findAllTechBooks(
-			keyword, PageRequest.of(page, size, Sort.Direction.DESC, sort.getValue())
+			keyword, memberId, educationId, PageRequest.of(page, size, Sort.Direction.DESC, sort.getValue())
 		);
 		return BaseResponse.success(SuccessCode.TECH_BOOK_LIST_FIND_SUCCESS, responseDto);
 	}

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
@@ -1,12 +1,9 @@
 package ssammudan.cotree.domain.education.techbook.dto;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import ssammudan.cotree.model.education.category.entity.EducationCategory;
-import ssammudan.cotree.model.education.techbook.category.entity.TechBookEducationCategory;
-import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 
 /**
  * PackageName : ssammudan.cotree.domain.education.dto
@@ -25,125 +22,44 @@ public class TechBookResponse {
 
 	@Schema(description = "TechBook 상세 조회 응답 DTO")
 	public record Detail(
-		//TODO: 구매 상태 정보 필요(비회원: 비구매, 회원: 구매 vs 비구매)
-		//TODO: 로그인한 회원의 좋아요 상태
-		@Schema(description = "TechBook ID", example = "1")
-		long id,                      //TechBook ID
-		@Schema(description = "TechBook 저자", example = "홍길동")
-		String writer,                //TechBook 저자
-		@Schema(description = "TechBook 교육 난이도", example = "입문")
-		String educationLevel,        //TechBook 교육 난이도
-		@Schema(description = "TechBook 교육 카테고리", example = "백엔드")
-		List<String> educationCategories,
-		@Schema(description = "TechBook 제목", example = "Spring Boot")
-		String title,                 //TechBook 제목
-		@Schema(description = "TechBook 설명", example = "스프링 부트를 1000% 활용하는 방법!!")
-		String description,           //TechBook 설명
-		@Schema(description = "TechBook 소개", example = "스프링 부트에 대한 수 많은 활용법을 담았습니다. ...")
-		String introduction,          //TechBook 소개
-		@Schema(description = "TechBook 평균 평점", example = "4.5")
-		double avgRating,             //TechBook 평균 평점
-		@Schema(description = "TechBook 전체 리뷰 수", example = "30")
-		int totalReviewCount,         //TechBook 전체 리뷰 수
-		@Schema(description = "TechBook PDF URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot.pdf")
-		String techBookUrl,           //TechBook PDF URL
-		@Schema(description = "TechBook PDF 미리보기 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_preview.pdf")
-		String techBookPreviewUrl,    //TechBook PDF 미리보기 URL
-		@Schema(description = "TechBook 썸네일 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_thumbnail.png")
-		String techBookThumbnailUrl,  //TechBook 썸네일 URL
-		@Schema(description = "TechBook 페이지 수", example = "100")
-		int techBookPage,             //TechBook 페이지 수
-		@Schema(description = "TechBook 가격", example = "10000")
-		int price,                    //TechBook 가격
-		@Schema(description = "TechBook 조회 수", example = "123")
-		int viewCount,                //TechBook 조회 수
-		@Schema(description = "TechBook 좋아요 수", example = "123")
-		long likeCount,                //TechBook 좋아요 수
-		@Schema(description = "로그인된 회원의 TechBook 좋아요 여부", example = "true")
-		boolean isLike,                //로그인된 회원의 TechBook 좋아요 여부
-		@Schema(description = "TechBook 등록 일자", example = "2025-01-01")
-		LocalDate createdAt           //TechBook 등록 일자
+		@Schema(description = "TechBook ID", example = "1") long id,
+		@Schema(description = "TechBook 저자", example = "홍길동") String writer,
+		@Schema(description = "TechBook 저자 프로필 이미지 URL") String writerProfileImageUrl,
+		@Schema(description = "TechBook 교육 난이도", example = "입문") String educationLevel,
+		@Schema(description = "TechBook 교육 카테고리", example = "백엔드") List<String> educationCategoryList,
+		@Schema(description = "TechBook 제목", example = "Spring Boot") String title,
+		@Schema(description = "TechBook 설명", example = "스프링 부트를 1000% 활용하는 방법!!") String description,
+		@Schema(description = "TechBook 소개", example = "스프링 부트에 대한 수 많은 활용법을 담았습니다. ...") String introduction,
+		@Schema(description = "TechBook 평균 평점", example = "4.5") double avgRating,
+		@Schema(description = "TechBook 전체 리뷰 수", example = "30") int totalReviewCount,
+		@Schema(description = "TechBook PDF URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot.pdf") String techBookUrl,
+		@Schema(description = "TechBook PDF 미리보기 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_preview.pdf") String techBookPreviewUrl,
+		@Schema(description = "TechBook 썸네일 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_thumbnail.png") String techBookThumbnailUrl,
+		@Schema(description = "TechBook 페이지 수", example = "100") int techBookPage,
+		@Schema(description = "TechBook 가격", example = "10000") int price,
+		@Schema(description = "TechBook 조회 수", example = "123") int viewCount,
+		@Schema(description = "TechBook 좋아요 수", example = "123") long likeCount,
+		@Schema(description = "로그인된 회원의 TechBook 좋아요 여부", example = "true") boolean isLike,
+		@Schema(description = "TechBook 등록 일자", example = "2025-01-01") LocalDateTime createdAt,
+		@Schema(description = "TechBook 결제 유무", example = "true") boolean isPaymentDone
 	) {
-		public static Detail from(final TechBook techBook) {
-			return new Detail(
-				techBook.getId(),
-				techBook.getWriter().getNickname(),
-				techBook.getEducationLevel().getName(),
-				techBook.getTechBookEducationCategories().stream()
-					.map(TechBookEducationCategory::getEducationCategory)
-					.map(EducationCategory::getName).toList(),    //TODO: 성능 최적화 시 FETCH JOIN 활용 형태 적용 고려
-				techBook.getTitle(),
-				techBook.getDescription(),
-				techBook.getIntroduction(),
-				(double)techBook.getTotalRating() / techBook.getTotalReviewCount(),
-				techBook.getTotalReviewCount(),
-				techBook.getTechBookUrl(),
-				techBook.getTechBookPreviewUrl(),
-				techBook.getTechBookThumbnailUrl(),
-				techBook.getTechBookPage(),
-				techBook.getPrice(),
-				techBook.getViewCount(),
-				techBook.getLikes().size(),
-				false,
-				techBook.getCreatedAt().toLocalDate()
-			);
-		}
-
-		public static Detail from(final TechBook techBook, final boolean isLike) {
-			return new Detail(
-				techBook.getId(),
-				techBook.getWriter().getNickname(),
-				techBook.getEducationLevel().getName(),
-				techBook.getTechBookEducationCategories().stream()
-					.map(TechBookEducationCategory::getEducationCategory)
-					.map(EducationCategory::getName).toList(),    //TODO: 성능 최적화 시 FETCH JOIN 활용 형태 적용 고려
-				techBook.getTitle(),
-				techBook.getDescription(),
-				techBook.getIntroduction(),
-				(double)techBook.getTotalRating() / techBook.getTotalReviewCount(),
-				techBook.getTotalReviewCount(),
-				techBook.getTechBookUrl(),
-				techBook.getTechBookPreviewUrl(),
-				techBook.getTechBookThumbnailUrl(),
-				techBook.getTechBookPage(),
-				techBook.getPrice(),
-				techBook.getViewCount(),
-				techBook.getLikes().size(),
-				isLike,
-				techBook.getCreatedAt().toLocalDate()
-			);
+		public void addEducationCategoryList(final List<String> categoryList) {
+			this.educationCategoryList.addAll(categoryList);
 		}
 	}
 
 	@Schema(description = "TechBook 목록 조회 응답 DTO")
 	public record ListInfo(
-		//TODO: 로그인한 회원의 좋아요 상태
-		@Schema(description = "TechBook ID", example = "1")
-		long id,    //TechBook ID
-		@Schema(description = "TechBook 저자", example = "홍길동")
-		String writer,    //TechBook 저자
-		@Schema(description = "TechBook 제목", example = "Spring Boot")
-		String title,    //TechBook 제목
-		@Schema(description = "TechBook 가격", example = "10000")
-		int price,    //TechBook 가격
-		@Schema(description = "TechBook 썸네일 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_thumbnail.png")
-		String techBookThumbnailUrl,    //TechBook 썸네일 URL
-		@Schema(description = "TechBook 좋아요 수", example = "123")
-		long likeCount,    //TechBook 좋아요 수
-		@Schema(description = "TechBook 등록 일자", example = "2025-01-01")
-		LocalDate createdAt    //TechBook 등록 일자
+		@Schema(description = "TechBook ID", example = "1") long id,
+		@Schema(description = "TechBook 저자", example = "홍길동") String writer,
+		@Schema(description = "TechBook 저자 프로필 이미지 URL") String writerProfileImageUrl,
+		@Schema(description = "TechBook 제목", example = "Spring Boot") String title,
+		@Schema(description = "TechBook 가격", example = "10000") int price,
+		@Schema(description = "TechBook 썸네일 URL", example = "https://cotree.ssammudan.com/techbook/SpringBoot_thumbnail.png") String techBookThumbnailUrl,
+		@Schema(description = "TechBook 좋아요 수", example = "123") long likeCount,
+		@Schema(description = "TechBook 등록 일자", example = "2025-01-01") LocalDateTime createdAt,
+		@Schema(description = "로그인된 회원의 좋아요 우무", example = "true") boolean isLike
 	) {
-		public static ListInfo from(final TechBook techBook) {
-			return new ListInfo(
-				techBook.getId(),
-				techBook.getWriter().getNickname(),
-				techBook.getTitle(),
-				techBook.getPrice(),
-				techBook.getTechBookThumbnailUrl(),
-				techBook.getLikes().size(),
-				techBook.getCreatedAt().toLocalDate()
-			);
-		}
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/dto/TechBookResponse.java
@@ -43,6 +43,31 @@ public class TechBookResponse {
 		@Schema(description = "TechBook 등록 일자", example = "2025-01-01") LocalDateTime createdAt,
 		@Schema(description = "TechBook 결제 유무", example = "true") boolean isPaymentDone
 	) {
+		public Detail withPurchaseCheck() {
+			return new Detail(
+				this.id,
+				this.writer,
+				this.writerProfileImageUrl,
+				this.educationLevel,
+				this.educationCategoryList,
+				this.title,
+				this.description,
+				this.introduction,
+				this.avgRating,
+				this.totalReviewCount,
+				this.isPaymentDone ? this.techBookUrl : null,
+				this.techBookPreviewUrl,
+				this.techBookThumbnailUrl,
+				this.techBookPage,
+				this.price,
+				this.viewCount,
+				this.likeCount,
+				this.isLike,
+				this.createdAt,
+				this.isPaymentDone
+			);
+		}
+
 		public void addEducationCategoryList(final List<String> categoryList) {
 			this.educationCategoryList.addAll(categoryList);
 		}

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookService.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookService.java
@@ -22,10 +22,10 @@ public interface TechBookService {
 
 	Long createTechBook(String memberId, TechBookRequest.Create requestDto);
 
-	TechBookResponse.Detail findTechBookById(Long id);
-
 	TechBookResponse.Detail findTechBookById(Long id, String memberId);
 
-	PageResponse<TechBookResponse.ListInfo> findAllTechBooks(String keyword, Pageable pageable);
+	PageResponse<TechBookResponse.ListInfo> findAllTechBooks(
+		String keyword, String memberId, Long educationId, Pageable pageable
+	);
 
 }

--- a/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceImpl.java
@@ -89,8 +89,7 @@ public class TechBookServiceImpl implements TechBookService {
 		if (!techBookRepository.existsById(id)) {
 			throw new GlobalException(ErrorCode.TECH_BOOK_NOT_FOUND);
 		}
-		//TODO: 조회 수 증가
-		return techBookRepository.findTechBook(id, memberId);
+		return techBookRepository.findTechBook(id, memberId).withPurchaseCheck();
 	}
 
 	/**

--- a/src/main/java/ssammudan/cotree/domain/review/dto/TechEducationReviewResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/review/dto/TechEducationReviewResponse.java
@@ -30,6 +30,8 @@ public class TechEducationReviewResponse {
 		long itemId,    //Item ID: TechBook ID, TechTube ID
 		@Schema(description = "TechEducation 리뷰 작성자", example = "홍길동")
 		String reviewer,    //리뷰 작성자 닉네임
+		@Schema(description = "TechEducation 리뷰 작성자 프로필 이미지 URL")
+		String profileImageUrl,    //리뷰 작성자 프로필 이미지
 		@Schema(description = "TechEducation 리뷰 평점", example = "5")
 		int rating,    //리뷰 평점
 		@Schema(description = "TechEducation 리뷰 내용", example = "스프링 부트의 다양한 기능을 활용하는 방법을 배울 수 있었습니다.")
@@ -43,6 +45,7 @@ public class TechEducationReviewResponse {
 				EducationType.getTechEducationType(techEducationReview.getTechEducationType().getId()),
 				techEducationReview.getItemId(),
 				techEducationReview.getReviewer().getNickname(),
+				techEducationReview.getReviewer().getProfileImageUrl(),
 				techEducationReview.getRating(),
 				techEducationReview.getContent(),
 				techEducationReview.getCreatedAt().toLocalDate()

--- a/src/main/java/ssammudan/cotree/domain/review/dto/TechEducationReviewResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/review/dto/TechEducationReviewResponse.java
@@ -1,8 +1,11 @@
 package ssammudan.cotree.domain.review.dto;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import ssammudan.cotree.model.education.type.EducationType;
 import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 
@@ -21,24 +24,46 @@ import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 public class TechEducationReviewResponse {
 
 	@Schema(description = "TechEducationReview 조회 DTO")
-	public record Detail(
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Detail {
 		@Schema(description = "TechEducation 리뷰 ID", example = "1")
-		long id,                    //TechEducationReview ID
+		long id;
 		@Schema(description = "TechEducation 타입: TECH_TUBE, TECH_BOOK", example = "TECH_TUBE")
-		EducationType techEducationType,    //TechEducationType: TECH_BOOK, TECH_TUBE
+		EducationType techEducationType;
 		@Schema(description = "TechEducationItem ID: TechBook ID, TechTube ID", example = "1")
-		long itemId,    //Item ID: TechBook ID, TechTube ID
+		long itemId;
 		@Schema(description = "TechEducation 리뷰 작성자", example = "홍길동")
-		String reviewer,    //리뷰 작성자 닉네임
+		String reviewer;
 		@Schema(description = "TechEducation 리뷰 작성자 프로필 이미지 URL")
-		String profileImageUrl,    //리뷰 작성자 프로필 이미지
+		String profileImageUrl;
 		@Schema(description = "TechEducation 리뷰 평점", example = "5")
-		int rating,    //리뷰 평점
+		int rating;
 		@Schema(description = "TechEducation 리뷰 내용", example = "스프링 부트의 다양한 기능을 활용하는 방법을 배울 수 있었습니다.")
-		String content,    //리뷰 내용,
+		String content;
 		@Schema(description = "TechEducation 리뷰 작성일자", example = "2025-01-01")
-		LocalDate createdAt    //리뷰 작성일자
-	) {
+		LocalDateTime createdAt;
+
+		public Detail(
+			final long id,
+			final long educationTypeId,
+			final long itemId,
+			final String reviewer,
+			final String profileImageUrl,
+			final int rating,
+			final String content,
+			final LocalDateTime createdAt
+		) {
+			this.id = id;
+			this.techEducationType = EducationType.getTechEducationType(educationTypeId);
+			this.itemId = itemId;
+			this.reviewer = reviewer;
+			this.profileImageUrl = profileImageUrl;
+			this.rating = rating;
+			this.content = content;
+			this.createdAt = createdAt;
+		}
+
 		public static Detail from(final TechEducationReview techEducationReview) {
 			return new Detail(
 				techEducationReview.getId(),
@@ -48,7 +73,7 @@ public class TechEducationReviewResponse {
 				techEducationReview.getReviewer().getProfileImageUrl(),
 				techEducationReview.getRating(),
 				techEducationReview.getContent(),
-				techEducationReview.getCreatedAt().toLocalDate()
+				techEducationReview.getCreatedAt()
 			);
 		}
 	}

--- a/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
@@ -107,10 +107,9 @@ public class TechEducationReviewServiceImpl implements TechEducationReviewServic
 	public PageResponse<TechEducationReviewResponse.Detail> findAllTechEducationReviews(
 		final TechEducationReviewRequest.Read requestDto, final Pageable pageable
 	) {
-		return PageResponse.of(techEducationReviewRepository.findAllTechEducationReviews(
-			EducationType.getTechEducationTypeId(
-				requestDto.techEducationType()), requestDto.itemId(), pageable
-		).map(TechEducationReviewResponse.Detail::from));
+		return PageResponse.of(techEducationReviewRepository.findReviews(
+			EducationType.getTechEducationTypeId(requestDto.techEducationType()), requestDto.itemId(), pageable
+		));
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceImpl.java
@@ -15,7 +15,9 @@ import ssammudan.cotree.model.education.techtube.techtube.repository.TechTubeRep
 import ssammudan.cotree.model.education.type.EducationType;
 import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.member.member.repository.MemberRepository;
+import ssammudan.cotree.model.payment.order.category.repository.OrderCategoryRepository;
 import ssammudan.cotree.model.payment.order.history.repository.OrderHistoryRepository;
+import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 import ssammudan.cotree.model.review.review.repository.TechEducationReviewRepository;
 import ssammudan.cotree.model.review.reviewtype.entity.TechEducationType;
@@ -43,6 +45,7 @@ public class TechEducationReviewServiceImpl implements TechEducationReviewServic
 	private final TechTubeRepository techTubeRepository;
 	private final TechBookRepository techBookRepository;
 	private final OrderHistoryRepository orderHistoryRepository;
+	private final OrderCategoryRepository orderCategoryRepository;
 
 	/**
 	 * TechEducationReview 신규 생성
@@ -63,8 +66,8 @@ public class TechEducationReviewServiceImpl implements TechEducationReviewServic
 		); //TechTube = 1 or TechBook = 2
 
 		//해당 리뷰 작성자가 구매한 제품이 맞는지 확인
-		if (!orderHistoryRepository.existsByCustomer_IdAndOrderCategory_IdAndProductId(
-			memberId, reviewTypeId, requestDto.itemId()
+		if (!orderHistoryRepository.existsByCustomer_IdAndOrderCategory_IdAndProductIdAndStatus(
+			memberId, reviewTypeId, requestDto.itemId(), PaymentStatus.SUCCESS
 		)) {
 			throw new GlobalException(ErrorCode.NO_PERMISSION_TO_WRITE_REVIEW);
 		}

--- a/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 	TECH_EDUCATION_REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "1006", "TechEducation 리뷰를 찾을 수 없습니다."),
 	TECH_EDUCATION_REVIEW_DUPLICATED(HttpStatus.BAD_REQUEST, "1007", "작성된 리뷰가 존재합니다."),
 	INVALID_EDUCATION_CATEGORY_ID(HttpStatus.BAD_REQUEST, "1008", "유효하지 않은 Education Category 입니다."),
+	NO_PERMISSION_TO_WRITE_REVIEW(HttpStatus.BAD_REQUEST, "1009", "리뷰 작성 권한이 없습니다."),
 
 	//Payment: 2001 ~ 3000
 	PAYMENT_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "2001", "결제는 완료되었으나, 서버 처리에 실패했습니다."),

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/entity/TechBook.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/entity/TechBook.java
@@ -238,16 +238,6 @@ public class TechBook extends BaseEntity {
 	}
 
 	/**
-	 * TechBook 조회 수 증가
-	 *
-	 * @return this
-	 */
-	public TechBook increseViewCount() {
-		this.viewCount += 1;
-		return this;
-	}
-
-	/**
 	 * TechBook 누적 리뷰 점수 추가
 	 *
 	 * @param rating - 리뷰 점수

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryCustom.java
@@ -3,6 +3,7 @@ package ssammudan.cotree.model.education.techbook.techbook.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
 import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 
 /**
@@ -19,6 +20,10 @@ import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
  */
 public interface TechBookRepositoryCustom {
 
+	TechBookResponse.Detail findTechBook(Long techBookId, String memberId);
+
 	Page<TechBook> findAllTechBooksByKeyword(String keyword, Pageable pageable);
+
+	Page<TechBookResponse.ListInfo> findTechBooks(String keyword, String memberId, Long educationId, Pageable pageable);
 
 }

--- a/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/education/techbook/techbook/repository/TechBookRepositoryImpl.java
@@ -9,17 +9,28 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
+import ssammudan.cotree.model.common.like.entity.QLike;
+import ssammudan.cotree.model.education.category.entity.QEducationCategory;
+import ssammudan.cotree.model.education.level.entity.QEducationLevel;
+import ssammudan.cotree.model.education.techbook.category.entity.QTechBookEducationCategory;
 import ssammudan.cotree.model.education.techbook.techbook.entity.QTechBook;
 import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
+import ssammudan.cotree.model.member.member.entity.QMember;
+import ssammudan.cotree.model.payment.order.category.entity.QOrderCategory;
+import ssammudan.cotree.model.payment.order.history.entity.QOrderHistory;
 
 /**
  * PackageName : ssammudan.cotree.model.education.techbook.techbook.repository
@@ -37,7 +48,84 @@ import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 @RequiredArgsConstructor
 public class TechBookRepositoryImpl implements TechBookRepositoryCustom {
 
+	private static final QTechBook techBook = QTechBook.techBook;
+	private static final QMember member = QMember.member;
+	private static final QEducationLevel educationLevel = QEducationLevel.educationLevel;
+	private static final QEducationCategory educationCategory = QEducationCategory.educationCategory;
+	private static final QTechBookEducationCategory techBookEducationCategory = QTechBookEducationCategory.techBookEducationCategory;
+	private static final QOrderHistory orderHistory = QOrderHistory.orderHistory;
+	private static final QOrderCategory orderCategory = QOrderCategory.orderCategory;
+	private static final QLike like = QLike.like;
+
 	private final JPAQueryFactory jpaQueryFactory;
+
+	/**
+	 * TechBook 상세 조회
+	 *
+	 * @param techBookId - TechBook ID
+	 * @param memberId   - 회원 ID
+	 * @return TechBookResponse Detail DTO
+	 */
+	@Override
+	public TechBookResponse.Detail findTechBook(final Long techBookId, final String memberId) {
+		TechBookResponse.Detail content = jpaQueryFactory.select(Projections.constructor(
+				TechBookResponse.Detail.class,
+				techBook.id,
+				member.nickname,
+				member.profileImageUrl,
+				educationLevel.name,
+				Expressions.constant(new ArrayList<String>()),
+				techBook.title,
+				techBook.description,
+				techBook.introduction,
+				Expressions.numberOperation(
+					Double.class,
+					Ops.DIV,
+					techBook.totalRating.castToNum(Double.class),
+					Expressions.numberTemplate(
+						Double.class, "CASE WHEN {0} = 0 THEN 1.0 ELSE {0} END", techBook.totalReviewCount
+					)
+				),
+				techBook.totalReviewCount,
+				techBook.techBookUrl,
+				techBook.techBookPreviewUrl,
+				techBook.techBookThumbnailUrl,
+				techBook.techBookPage,
+				techBook.price,
+				techBook.viewCount,
+				JPAExpressions.select(like.count()).from(like).where(like.techBook.id.eq(techBookId)),
+				memberId != null
+					? JPAExpressions.select(like.count()).from(like)
+					.where(like.techBook.id.eq(techBook.id).and(like.member.id.eq(memberId))).exists()
+					: Expressions.constant(Boolean.FALSE),
+				techBook.createdAt,
+				memberId != null
+					? JPAExpressions.select(orderHistory.count()).from(orderHistory)
+					.join(orderHistory).on(orderHistory.orderCategory.id.eq(orderCategory.id))
+					.where(orderHistory.customer.id.eq(memberId)
+						.and(orderHistory.productId.eq(techBookId))
+						.and(orderCategory.name.eq("TechBook")))
+					.exists()
+					: Expressions.constant(Boolean.FALSE)
+			))
+			.from(techBook)
+			.join(member).on(techBook.writer.id.eq(member.id))
+			.join(educationLevel).on(techBook.educationLevel.id.eq(educationLevel.id))
+			.where(techBook.id.eq(techBookId))
+			.fetchOne();
+
+		if (content != null) {
+			List<String> categoryList = jpaQueryFactory.select(educationCategory.name)
+				.from(techBookEducationCategory)
+				.join(educationCategory).on(techBookEducationCategory.educationCategory.id.eq(educationCategory.id))
+				.where(techBookEducationCategory.techBook.id.eq(techBookId))
+				.fetch();
+
+			content.addEducationCategoryList(categoryList);
+		}
+
+		return content;
+	}
 
 	/**
 	 * 검색어(keyword)로 TechBook 페이징 목록 조회
@@ -50,25 +138,86 @@ public class TechBookRepositoryImpl implements TechBookRepositoryCustom {
 	public Page<TechBook> findAllTechBooksByKeyword(final String keyword, final Pageable pageable) {
 		QTechBook techBook = QTechBook.techBook;
 		List<TechBook> content = jpaQueryFactory.selectFrom(techBook)
-			.where(getSearchCondition(keyword, techBook))
-			.orderBy(getSortCondition(pageable, techBook))
+			.where(getSearchCondition(keyword))
+			.orderBy(getSortCondition(pageable))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
 		JPAQuery<Long> count = jpaQueryFactory.select(techBook.count())
 			.from(techBook)
-			.where(getSearchCondition(keyword, techBook));
+			.where(getSearchCondition(keyword));
 		return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+	}
+
+	/**
+	 * 검색어(keyword)로 TechBook 페이징 목록 조회
+	 *
+	 * @param keyword     - 검색어
+	 * @param memberId    - 회원 ID
+	 * @param educationId - 교육 카테고리 ID
+	 * @param pageable    - 페이징 객체
+	 * @return Page<TechBookResponse.ListInfo>
+	 */
+	@Override
+	public Page<TechBookResponse.ListInfo> findTechBooks(
+		final String keyword, final String memberId, final Long educationId, final Pageable pageable
+	) {
+		JPAQuery<TechBookResponse.ListInfo> contentJpaQuery = jpaQueryFactory.select(Projections.constructor(
+				TechBookResponse.ListInfo.class,
+				techBook.id,
+				member.nickname,
+				member.profileImageUrl,
+				techBook.title,
+				techBook.price,
+				techBook.techBookThumbnailUrl,
+				JPAExpressions.select(like.count()).from(like).where(like.techBook.id.eq(techBook.id)),
+				techBook.createdAt,
+				memberId != null
+					? JPAExpressions.select(like.count()).from(like)
+					.where(like.techBook.id.eq(techBook.id).and(like.member.id.eq(memberId))).exists()
+					: Expressions.constant(Boolean.FALSE)
+			)).from(techBook)
+			.join(member).on(techBook.writer.id.eq(member.id))
+			.where(getSearchCondition(keyword))
+			.orderBy(getSortCondition(pageable))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize());
+
+		addJoinByEducationCategory(contentJpaQuery, educationId);
+
+		List<TechBookResponse.ListInfo> content = contentJpaQuery.fetch();
+
+		JPAQuery<Long> countJpaQuery = jpaQueryFactory.select(techBook.count())
+			.from(techBook)
+			.where(getSearchCondition(keyword));
+
+		addJoinByEducationCategory(countJpaQuery, educationId);
+
+		return PageableExecutionUtils.getPage(content, pageable, countJpaQuery::fetchOne);
+	}
+
+	/**
+	 * 교육 카테고리 ID 유무에 따라 동적 쿼리 추가
+	 *
+	 * @param jpaQuery    - JPAQuery
+	 * @param educationId - 교육 카테고리 ID
+	 * @param <T>
+	 */
+	private <T> void addJoinByEducationCategory(final JPAQuery<T> jpaQuery, final Long educationId) {
+		if (educationId != null) {
+			jpaQuery.join(techBookEducationCategory)
+				.on(techBook.id.eq(techBookEducationCategory.techBook.id)
+					.and(techBookEducationCategory.educationCategory.id.eq(educationId)));
+		}
 	}
 
 	/**
 	 * 검색어(keyword) 기준 BooleanExpression 생성
 	 *
 	 * @param keyword  - 검색어
-	 * @param techBook - Querydsl TechBook
 	 * @return BooleanExpression
 	 */
-	private BooleanExpression getSearchCondition(final String keyword, @NotNull final QTechBook techBook) {
+	private BooleanExpression getSearchCondition(final String keyword) {
 		BooleanExpression expression = null;
 
 		if (StringUtils.hasText(keyword)) {
@@ -84,10 +233,9 @@ public class TechBookRepositoryImpl implements TechBookRepositoryCustom {
 	 * 페이징 객체에 포함된 정렬 조건에 따라 OrderSpecifier[] 생성
 	 *
 	 * @param pageable - 페이징 객체
-	 * @param techBook - Querydsl TechBook
 	 * @return OrderSpecifier[]
 	 */
-	private OrderSpecifier<?>[] getSortCondition(@NotNull final Pageable pageable, @NotNull final QTechBook techBook) {
+	private OrderSpecifier<?>[] getSortCondition(@NotNull final Pageable pageable) {
 		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
 		boolean hasCreatedAt = pageable.getSort().stream().anyMatch(order -> "createdAt".equals(order.getProperty()));
 

--- a/src/main/java/ssammudan/cotree/model/payment/order/history/repository/OrderHistoryRepository.java
+++ b/src/main/java/ssammudan/cotree/model/payment/order/history/repository/OrderHistoryRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
+import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 
 /**
  * PackageName : ssammudan.cotree.model.payment.order.history.repository
@@ -26,6 +27,8 @@ public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long
 
 	boolean existsByOrderId(String orderId);
 
-	boolean existsByCustomer_IdAndOrderCategory_IdAndProductId(String customerId, Long orderCategoryId, Long productId);
+	boolean existsByCustomer_IdAndOrderCategory_IdAndProductIdAndStatus(
+		String customerId, Long orderCategoryId, Long productId, PaymentStatus status
+	);
 
 }

--- a/src/main/java/ssammudan/cotree/model/payment/order/history/repository/OrderHistoryRepository.java
+++ b/src/main/java/ssammudan/cotree/model/payment/order/history/repository/OrderHistoryRepository.java
@@ -26,4 +26,6 @@ public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long
 
 	boolean existsByOrderId(String orderId);
 
+	boolean existsByCustomer_IdAndOrderCategory_IdAndProductId(String customerId, Long orderCategoryId, Long productId);
+
 }

--- a/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/review/review/repository/TechEducationReviewRepositoryCustom.java
@@ -3,6 +3,7 @@ package ssammudan.cotree.model.review.review.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import ssammudan.cotree.domain.review.dto.TechEducationReviewResponse;
 import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 
 /**
@@ -19,6 +20,10 @@ import ssammudan.cotree.model.review.review.entity.TechEducationReview;
 public interface TechEducationReviewRepositoryCustom {
 
 	Page<TechEducationReview> findAllTechEducationReviews(
+		final Long techEducationTypeId, final Long itemId, final Pageable pageable
+	);
+
+	Page<TechEducationReviewResponse.Detail> findReviews(
 		final Long techEducationTypeId, final Long itemId, final Pageable pageable
 	);
 

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/controller/TechBookControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/controller/TechBookControllerTest.java
@@ -26,12 +26,12 @@ import net.jqwik.api.Arbitraries;
 import autoparams.AutoSource;
 import autoparams.Repeat;
 import ssammudan.cotree.domain.education.techbook.dto.TechBookResponse;
+import ssammudan.cotree.global.annotation.CustomWithMockUser;
 import ssammudan.cotree.global.response.BaseResponse;
 import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 import ssammudan.cotree.integration.WebMvcTestSupporter;
-import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 
 /**
  * PackageName : ssammudan.cotree.domain.education.techbook.controller
@@ -48,38 +48,35 @@ import ssammudan.cotree.model.education.techbook.techbook.entity.TechBook;
 class TechBookControllerTest extends WebMvcTestSupporter {
 
 	private TechBookResponse.Detail createTechBookResponseDetail(final Long id) {
-		return TechBookResponse.Detail.from(entityFixtureMonkey.giveMeBuilder(TechBook.class)
+		return dtoFixtureMonkey.giveMeBuilder(TechBookResponse.Detail.class)
 			.set("id", id)
-			.set("totalRating", Arbitraries.integers().greaterOrEqual(0))
+			.set("avgRating", Arbitraries.doubles().between(0, 5))
 			.set("totalReviewCount", Arbitraries.integers().greaterOrEqual(0))
 			.set("techBookPage", Arbitraries.integers().greaterOrEqual(0))
 			.set("price", Arbitraries.integers().greaterOrEqual(0))
 			.set("viewCount", Arbitraries.integers().greaterOrEqual(0))
-			.sample());
+			.set("likeCount", Arbitraries.longs().greaterOrEqual(0))
+			.sample();
 	}
 
 	private List<TechBookResponse.ListInfo> createTechBookResponseListInfo(final int size) {
-		return entityFixtureMonkey.giveMeBuilder(TechBook.class)
-			.set("totalRating", Arbitraries.integers().greaterOrEqual(0))
-			.set("totalReviewCount", Arbitraries.integers().greaterOrEqual(0))
-			.set("techBookPage", Arbitraries.integers().greaterOrEqual(0))
+		return dtoFixtureMonkey.giveMeBuilder(TechBookResponse.ListInfo.class)
+			.set("id", Arbitraries.longs().greaterOrEqual(1))
+			.set("likeCount", Arbitraries.longs().greaterOrEqual(0))
 			.set("price", Arbitraries.integers().greaterOrEqual(0))
-			.set("viewCount", Arbitraries.integers().greaterOrEqual(0))
-			.sampleList(size)
-			.stream()
-			.map(TechBookResponse.ListInfo::from)
-			.toList();
+			.sampleList(size);
 	}
 
 	@ParameterizedTest
 	@AutoSource
 	@Repeat(10)
+	@CustomWithMockUser
 	@DisplayName("[Success] getTechBookById(): TechBook 단 건 조회")
 	void getTechBookById(@Min(1) @Max(Long.MAX_VALUE) final Long id) throws Exception {
 		//Given
 		TechBookResponse.Detail responseDto = createTechBookResponseDetail(id);
 
-		when(techBookService.findTechBookById(id)).thenReturn(responseDto);
+		when(techBookService.findTechBookById(eq(id), any())).thenReturn(responseDto);
 
 		//When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/education/techbook/{id}/info", id));
@@ -100,6 +97,7 @@ class TechBookControllerTest extends WebMvcTestSupporter {
 	@ParameterizedTest
 	@AutoSource
 	@Repeat(10)
+	@CustomWithMockUser
 	@DisplayName("[Invalid] getTechBookById_invalidId(): TechBook 단 건 조회, Invalid ID")
 	void getTechBookById_unknownId(@Min(Long.MIN_VALUE) @Max(0) final Long invalidId) throws Exception {
 		//Given
@@ -120,30 +118,33 @@ class TechBookControllerTest extends WebMvcTestSupporter {
 
 	//@RepeatedTest(10)
 	@Test
+	@CustomWithMockUser
 	@DisplayName("[Success] getTechBooks(): TechBook 다 건 조회, 페이징 적용")
 	void getTechBooks() throws Exception {
 		//Given
 		List<TechBookResponse.ListInfo> content = createTechBookResponseListInfo(50);
-		PageResponse<TechBookResponse.ListInfo> resopnseDto = PageResponse.of(new PageImpl<>(
+		PageResponse<TechBookResponse.ListInfo> responseDto = PageResponse.of(new PageImpl<>(
 			content,
 			PageRequest.of(0, 16, Sort.Direction.DESC, "createdAt"),
 			content.size()
 		));
 
-		when(techBookService.findAllTechBooks(anyString(), any(Pageable.class))).thenReturn(resopnseDto);
+		when(techBookService.findAllTechBooks(anyString(), any(), anyLong(), any(Pageable.class))).thenReturn(
+			responseDto);
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 		params.add("page", "0");
 		params.add("size", "16");
 		params.add("sort", "LATEST");
 		params.add("keyword", dtoFixtureMonkey.giveMeOne(String.class));
+		params.add("categoryId", "1");
 
 		//When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/education/techbook").params(params));
 
 		//Then
 		BaseResponse<PageResponse<TechBookResponse.ListInfo>> baseResponse = BaseResponse.success(
-			SuccessCode.TECH_BOOK_LIST_FIND_SUCCESS, resopnseDto
+			SuccessCode.TECH_BOOK_LIST_FIND_SUCCESS, responseDto
 		);
 		String responseBody = objectMapper.writeValueAsString(baseResponse);
 

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -259,7 +259,6 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 		assertEquals(responseDto.techBookThumbnailUrl(), techBook.getTechBookThumbnailUrl(), "썸네일 URL 일치");
 		assertEquals(responseDto.techBookPage(), techBook.getTechBookPage(), "페이지 수 일치");
 		assertEquals(responseDto.price(), techBook.getPrice(), "가격 일치");
-		assertEquals(responseDto.viewCount(), techBook.getViewCount(), "조회 수 일치");    //TODO: 조회 수 증가 로직 추가 시 변경
 		assertEquals(responseDto.likeCount(), techBook.getLikes().size(), "좋아요 수 일치");
 		assertTrue(responseDto.isLike(), "좋아요 여부");
 		assertEquals(responseDto.createdAt().toLocalDate(), techBook.getCreatedAt().toLocalDate(), "등록 일자 일치");

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -2,8 +2,6 @@ package ssammudan.cotree.domain.education.techbook.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.temporal.ChronoUnit;
-import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,10 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import net.jqwik.api.Arbitraries;
 
@@ -231,62 +226,6 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 
 	//@RepeatedTest(10)
 	@Test
-	@DisplayName("[Success] findTechBookById(): TechBook 단 건 조회")
-	void findTechBookById() {
-		//Given
-		setup();
-
-		Member member = createMember();
-		em.persist(member);
-		EducationLevel educationLevel = createEducationLevel();
-		em.persist(educationLevel);
-		TechBook techBook = createTechBook(member, educationLevel);
-		em.persist(techBook);
-
-		Long id = techBook.getId();
-		clearEntityContext();
-
-		//When
-		TechBookResponse.Detail responseDto = techBookService.findTechBookById(id);
-
-		//Then
-		assertNotNull(responseDto, "TechBook 응답 DTO 존재");
-		assertEquals(responseDto.id(), techBook.getId(), "PK 일치");
-		assertEquals(responseDto.educationLevel(), techBook.getEducationLevel().getName(), "학습 난이도 일치");
-		assertEquals(responseDto.title(), techBook.getTitle(), "제목 일치");
-		assertEquals(responseDto.description(), techBook.getDescription(), "설명 일치");
-		assertEquals(responseDto.introduction(), techBook.getIntroduction(), "소개 일치");
-		assertEquals(responseDto.totalReviewCount(), techBook.getTotalReviewCount(), "전체 리뷰 수 일치");
-		assertEquals(responseDto.techBookUrl(), techBook.getTechBookUrl(), "PDF URL 일치");
-		assertEquals(responseDto.techBookPreviewUrl(), techBook.getTechBookPreviewUrl(), "PDF 미리보기 URL 일치");
-		assertEquals(responseDto.techBookThumbnailUrl(), techBook.getTechBookThumbnailUrl(), "썸네일 URL 일치");
-		assertEquals(responseDto.techBookPage(), techBook.getTechBookPage(), "페이지 수 일치");
-		assertEquals(responseDto.price(), techBook.getPrice(), "가격 일치");
-		assertEquals(responseDto.viewCount(), techBook.getViewCount() + 1, "조회 수 일치");
-		assertEquals(responseDto.likeCount(), techBook.getLikes().size(), "좋아요 수 일치");
-		assertFalse(responseDto.isLike(), "좋아요 여부");
-		assertEquals(responseDto.createdAt(), techBook.getCreatedAt().toLocalDate(), "등록 일자 일치");
-	}
-
-	@ParameterizedTest
-	@AutoSource
-	@Repeat(10)
-	@DisplayName("[Exception] findTechBookById_unknownId(): TechBook 단 건 조회, 존재하지 않는 ID")
-	void findTechBookById_unknownId(@Min(1) @Max(Long.MAX_VALUE) final Long unknownId) {
-		//Given
-
-		//When
-
-		//Then
-		GlobalException globalException = assertThrows(GlobalException.class,
-			() -> techBookService.findTechBookById(unknownId), "GlobalException 발생");
-
-		assertAll(() -> assertNotNull(globalException, "예외 존재"),
-			() -> assertEquals(globalException.getErrorCode(), ErrorCode.TECH_BOOK_NOT_FOUND, "에러 코드 일치"));
-	}
-
-	//@RepeatedTest(10)
-	@Test
 	@DisplayName("[Success] findTechBookById(): 좋아요한 회원 ID와 함께 TechBook 단 건 조회")
 	void findTechBookByIdAndMemberId() {
 		//Given
@@ -320,10 +259,10 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 		assertEquals(responseDto.techBookThumbnailUrl(), techBook.getTechBookThumbnailUrl(), "썸네일 URL 일치");
 		assertEquals(responseDto.techBookPage(), techBook.getTechBookPage(), "페이지 수 일치");
 		assertEquals(responseDto.price(), techBook.getPrice(), "가격 일치");
-		assertEquals(responseDto.viewCount(), techBook.getViewCount() + 1, "조회 수 일치");
+		assertEquals(responseDto.viewCount(), techBook.getViewCount(), "조회 수 일치");    //TODO: 조회 수 증가 로직 추가 시 변경
 		assertEquals(responseDto.likeCount(), techBook.getLikes().size(), "좋아요 수 일치");
 		assertTrue(responseDto.isLike(), "좋아요 여부");
-		assertEquals(responseDto.createdAt(), techBook.getCreatedAt().toLocalDate(), "등록 일자 일치");
+		assertEquals(responseDto.createdAt().toLocalDate(), techBook.getCreatedAt().toLocalDate(), "등록 일자 일치");
 	}
 
 	@ParameterizedTest
@@ -346,84 +285,6 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 
 		assertAll(() -> assertNotNull(globalException, "예외 존재"),
 			() -> assertEquals(globalException.getErrorCode(), ErrorCode.TECH_BOOK_NOT_FOUND, "에러 코드 일치"));
-	}
-
-	//@RepeatedTest(10)
-	@Test
-	@DisplayName("[Exception] findTechBookById_unknownId(): 좋아요한 회원 ID와 함께 TechBook 단 건 조회, 존재하지 않는 회원 ID")
-	void findTechBookByIdAndMemberId_unknownId() {
-		//Given
-		setup();
-
-		Member member = createMember();
-		em.persist(member);
-		EducationLevel educationLevel = createEducationLevel();
-		em.persist(educationLevel);
-		TechBook techBook = createTechBook(member, educationLevel);
-		em.persist(techBook);
-
-		Long id = techBook.getId();
-		clearEntityContext();
-
-		String unknownMemberId = UUID.randomUUID().toString();
-
-		//When
-
-		//Then
-		GlobalException globalException = assertThrows(GlobalException.class,
-			() -> techBookService.findTechBookById(id, unknownMemberId), "GlobalException 발생");
-
-		assertAll(() -> assertNotNull(globalException, "예외 존재"),
-			() -> assertEquals(globalException.getErrorCode(), ErrorCode.MEMBER_NOT_FOUND, "에러 코드 일치"));
-	}
-
-	//@RepeatedTest(10)
-	@Test
-	@DisplayName("[Success] findAllTechBooks(): TechBook 다 건 조회, 페이징 적용")
-	void findAllTechBooks() {
-		//Given
-		setup();
-
-		Member member = createMember();
-		em.persist(member);
-		EducationLevel educationLevel = createEducationLevel();
-		em.persist(educationLevel);
-		List<TechBook> techBooks = createTechBooks(member, educationLevel, 50);
-		techBooks.forEach(techBook -> em.persist(techBook));
-		clearEntityContext();
-
-		String keyword = dtoFixtureMonkey.giveMeOne(String.class);
-		PageRequest pageable = PageRequest.of(0, 16, Sort.Direction.DESC, "createdAt");
-
-		//When
-		List<TechBookResponse.ListInfo> findAllTechBookResponseDto = techBookService.findAllTechBooks(keyword, pageable)
-			.getContent();
-
-		//Then
-		List<TechBookResponse.ListInfo> filteredTechBookResponseDto = techBooks.stream()
-			.filter(techBook -> !StringUtils.hasText(keyword) || (techBook.getTitle().contains(keyword)
-				|| techBook.getDescription().contains(keyword) || techBook.getIntroduction().contains(keyword)))
-			.sorted(Comparator.comparing(TechBook::getCreatedAt)
-				.reversed()
-				.thenComparing(book -> book.getCreatedAt().truncatedTo(ChronoUnit.MILLIS), Comparator.reverseOrder()))
-			.limit(pageable.getPageSize())
-			.map(TechBookResponse.ListInfo::from)
-			.toList();
-
-		assertEquals(filteredTechBookResponseDto.size(), findAllTechBookResponseDto.size(), "검색 결과 갯수 일치");
-		for (int i = 0; i < filteredTechBookResponseDto.size(); i++) {
-			TechBookResponse.ListInfo filteredTechBookDto = filteredTechBookResponseDto.get(i);
-			TechBookResponse.ListInfo findTechBookDto = findAllTechBookResponseDto.get(i);
-
-			assertEquals(filteredTechBookDto.id(), findTechBookDto.id(), "PK 일치");
-			assertEquals(filteredTechBookDto.writer(), findTechBookDto.writer(), "저자 일치");
-			assertEquals(filteredTechBookDto.title(), findTechBookDto.title(), "제목 일치");
-			assertEquals(filteredTechBookDto.price(), findTechBookDto.price(), "가격 일치");
-			assertEquals(filteredTechBookDto.techBookThumbnailUrl(), findTechBookDto.techBookThumbnailUrl(),
-				"썸네일 URL 일치");
-			assertEquals(filteredTechBookDto.likeCount(), findTechBookDto.likeCount(), "좋아요 수 일치");
-			assertEquals(filteredTechBookDto.createdAt(), findTechBookDto.createdAt(), "등록 일자 일치");
-		}
 	}
 
 }

--- a/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/education/techbook/service/TechBookServiceTest.java
@@ -254,7 +254,6 @@ class TechBookServiceTest extends SpringBootTestSupporter {
 		assertEquals(responseDto.description(), techBook.getDescription(), "설명 일치");
 		assertEquals(responseDto.introduction(), techBook.getIntroduction(), "소개 일치");
 		assertEquals(responseDto.totalReviewCount(), techBook.getTotalReviewCount(), "전체 리뷰 수 일치");
-		assertEquals(responseDto.techBookUrl(), techBook.getTechBookUrl(), "PDF URL 일치");
 		assertEquals(responseDto.techBookPreviewUrl(), techBook.getTechBookPreviewUrl(), "PDF 미리보기 URL 일치");
 		assertEquals(responseDto.techBookThumbnailUrl(), techBook.getTechBookThumbnailUrl(), "썸네일 URL 일치");
 		assertEquals(responseDto.techBookPage(), techBook.getTechBookPage(), "페이지 수 일치");

--- a/src/test/java/ssammudan/cotree/domain/review/controller/TechEducationReviewControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/review/controller/TechEducationReviewControllerTest.java
@@ -2,6 +2,7 @@ package ssammudan.cotree.domain.review.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -87,6 +88,7 @@ class TechEducationReviewControllerTest extends WebMvcTestSupporter {
 
 		//When
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/education/review")
+			.with(csrf())
 			.contentType(MediaType.APPLICATION_JSON_VALUE)
 			.content(requestBody));
 
@@ -104,6 +106,7 @@ class TechEducationReviewControllerTest extends WebMvcTestSupporter {
 	@ParameterizedTest
 	@AutoSource
 	@Repeat(10)
+	@CustomWithMockUser
 	@DisplayName("[Success] getTechEducationReviews(): TechEducation 리뷰 다 건 조회, 페이징 적용")
 	void getTechEducationReviews(@Min(1) @Max(Long.MAX_VALUE) final Long itemId) throws Exception {
 		//Given

--- a/src/test/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceTest.java
+++ b/src/test/java/ssammudan/cotree/domain/review/service/TechEducationReviewServiceTest.java
@@ -2,7 +2,6 @@ package ssammudan.cotree.domain.review.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -393,12 +392,12 @@ class TechEducationReviewServiceTest extends SpringBootTestSupporter {
 			TechEducationReviewResponse.Detail sortedReviewDto = sortedTechEducationReviewResponseDto.get(i);
 			TechEducationReviewResponse.Detail findReviewDto = findAllTechEducationReviewResopnseDto.get(i);
 
-			assertEquals(sortedReviewDto.id(), findReviewDto.id(), "PK 일치");
-			assertEquals(sortedReviewDto.techEducationType(), findReviewDto.techEducationType(), "교육 컨텐츠 타입 일치");
-			assertEquals(sortedReviewDto.itemId(), findReviewDto.itemId(), "교육 컨텐츠 ID 일치");
-			assertEquals(sortedReviewDto.reviewer(), findReviewDto.reviewer(), "리뷰 작성자 일치");
-			assertEquals(sortedReviewDto.rating(), findReviewDto.rating(), "리뷰 점수 일치");
-			assertEquals(sortedReviewDto.content(), findReviewDto.content(), "리뷰 내용 일치");
+			assertEquals(sortedReviewDto.getId(), findReviewDto.getId(), "PK 일치");
+			assertEquals(sortedReviewDto.getTechEducationType(), findReviewDto.getTechEducationType(), "교육 컨텐츠 타입 일치");
+			assertEquals(sortedReviewDto.getItemId(), findReviewDto.getItemId(), "교육 컨텐츠 ID 일치");
+			assertEquals(sortedReviewDto.getReviewer(), findReviewDto.getReviewer(), "리뷰 작성자 일치");
+			assertEquals(sortedReviewDto.getRating(), findReviewDto.getRating(), "리뷰 점수 일치");
+			assertEquals(sortedReviewDto.getContent(), findReviewDto.getContent(), "리뷰 내용 일치");
 		}
 	}
 

--- a/src/test/java/ssammudan/cotree/integration/WebMvcTestSupporter.java
+++ b/src/test/java/ssammudan/cotree/integration/WebMvcTestSupporter.java
@@ -1,7 +1,6 @@
 package ssammudan.cotree.integration;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -42,7 +41,6 @@ import com.navercorp.fixturemonkey.mockito.plugin.MockitoPlugin;
  */
 @WebMvcTest({TechBookController.class, TechTubeController.class, TechEducationReviewController.class})
 @Import({TestWebConfig.class})
-@AutoConfigureMockMvc(addFilters = false)  // Security 비활성화
 public abstract class WebMvcTestSupporter {
 
 	protected final FixtureMonkey entityFixtureMonkey = FixtureMonkey.builder()


### PR DESCRIPTION
…tents-add-field<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
close #150 
  <br/>

## 🔎 작업 내용
- TechBook 응답 DTO 필드 정리
  - 누락 데이터: 프로필 이미지 URL, 구매 여부(isPaymentDone) 필드 추가
  - 리포지토리에서 Querydsl 프로젝션 사용(* TechTube 참조)
  - 기존 메서드 변경/삭제에 따른 테스트 코드 제거 및 수정
- 교육 컨텐츠 리뷰(TechEducationReview) 응답 시 프로젝션 사용으로 변경
- 교육 컨텐츠 리뷰 작성 시 구매 이력 확인 로직 추가
  - 로그인한 회원이 리뷰 작성 대상 제품 구매 기록이 없다면 예외

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>…tents-add-field