### PR TITLE
[FEAT] #MIO-1 회원정보 조회 - 구매 목록

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/member/controller/MemberController.java
+++ b/src/main/java/ssammudan/cotree/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.member.dto.MemberOrderResponse;
 import ssammudan.cotree.domain.member.dto.MemberRecoverSmsRequest;
 import ssammudan.cotree.domain.member.dto.MemberRecoverSmsResponse;
 import ssammudan.cotree.domain.member.dto.MemberRecoverSmsVerifyRequest;
@@ -28,12 +30,14 @@ import ssammudan.cotree.domain.member.dto.signup.MemberSignupRequest;
 import ssammudan.cotree.domain.member.dto.signup.MemberSignupSmsRequest;
 import ssammudan.cotree.domain.member.dto.signup.MemberSignupSmsVerifyRequest;
 import ssammudan.cotree.domain.member.service.MemberService;
+import ssammudan.cotree.domain.member.type.OrderProductCategoryType;
 import ssammudan.cotree.domain.phone.service.SmsService;
 import ssammudan.cotree.global.config.security.jwt.AccessTokenService;
 import ssammudan.cotree.global.config.security.jwt.RefreshTokenService;
 import ssammudan.cotree.global.config.security.jwt.TokenBlacklistService;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.global.response.SuccessCode;
 import ssammudan.cotree.model.member.member.entity.Member;
 
@@ -138,6 +142,18 @@ public class MemberController {
 		@Valid @RequestBody MemberRecoverSmsVerifyRequest request) {
 		return BaseResponse.success(SuccessCode.MEMBER_RECOVER_CODE_VERIFY_SUCCESS,
 			smsService.verifyRecoverLoginId(request));
+	}
+
+	@GetMapping("/order")
+	@Operation(summary = "구매목록 조회", description = "마이페이지의 구매목록을 조회합니다.")
+	public BaseResponse<PageResponse<MemberOrderResponse>> getOrderList(
+		@RequestParam(value = "page", defaultValue = "0", required = false) int page,
+		@RequestParam(value = "size", defaultValue = "12", required = false) int size,
+		@RequestParam(value = "type", defaultValue = "TECH_TUBE", required = false) OrderProductCategoryType type,
+		@AuthenticationPrincipal CustomUser customUser
+	) {
+		return BaseResponse.success(SuccessCode.MEMBER_ORDER_LIST_FIND_SUCCESS,
+			memberService.getOrderList(page, size, type, customUser.getId()));
 	}
 
 	private String getValueInCookie(String value, HttpServletRequest request) {

--- a/src/main/java/ssammudan/cotree/domain/member/dto/MemberOrderResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/member/dto/MemberOrderResponse.java
@@ -1,0 +1,24 @@
+package ssammudan.cotree.domain.member.dto;
+
+import lombok.Builder;
+
+/**
+ * PackageName : ssammudan.cotree.domain.member.dto
+ * FileName    : MemberOrderResponse
+ * Author      : kwak
+ * Date        : 2025. 4. 8.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 8.     kwak               Initial creation
+ */
+@Builder
+public record MemberOrderResponse(
+	Long productId,
+	String productType,
+	String thumbnail,
+	String title,
+	String author
+) {
+}

--- a/src/main/java/ssammudan/cotree/domain/member/service/MemberService.java
+++ b/src/main/java/ssammudan/cotree/domain/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package ssammudan.cotree.domain.member.service;
 
+import ssammudan.cotree.domain.member.dto.MemberOrderResponse;
 import ssammudan.cotree.domain.member.dto.info.MemberInfoRequest;
 import ssammudan.cotree.domain.member.dto.info.MemberInfoResponse;
 import ssammudan.cotree.domain.member.dto.signin.MemberSigninRequest;
 import ssammudan.cotree.domain.member.dto.signup.MemberSignupRequest;
+import ssammudan.cotree.domain.member.type.OrderProductCategoryType;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.model.member.member.entity.Member;
 
 public interface MemberService {
@@ -16,4 +19,7 @@ public interface MemberService {
 	Member findById(String memberId);
 
 	MemberInfoResponse getMemberInfo(String id);
+
+	PageResponse<MemberOrderResponse> getOrderList(int page, int size, OrderProductCategoryType type, String id);
+
 }

--- a/src/main/java/ssammudan/cotree/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/member/service/MemberServiceImpl.java
@@ -1,19 +1,25 @@
 package ssammudan.cotree.domain.member.service;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ssammudan.cotree.domain.member.dto.MemberOrderResponse;
 import ssammudan.cotree.domain.member.dto.info.MemberInfoRequest;
 import ssammudan.cotree.domain.member.dto.info.MemberInfoResponse;
 import ssammudan.cotree.domain.member.dto.signin.MemberSigninRequest;
 import ssammudan.cotree.domain.member.dto.signup.MemberSignupRequest;
+import ssammudan.cotree.domain.member.type.OrderProductCategoryType;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.member.member.repository.MemberRepository;
 
@@ -85,5 +91,14 @@ public class MemberServiceImpl implements MemberService {
 		Member member = memberRepository.findById(id)
 			.orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
 		return new MemberInfoResponse(member);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public PageResponse<MemberOrderResponse> getOrderList(int page, int size, OrderProductCategoryType type,
+		String id) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<MemberOrderResponse> orderList = memberRepository.getOrderList(pageable, type, id);
+		return PageResponse.of(orderList);
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/member/type/OrderProductCategoryType.java
+++ b/src/main/java/ssammudan/cotree/domain/member/type/OrderProductCategoryType.java
@@ -1,0 +1,25 @@
+package ssammudan.cotree.domain.member.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * PackageName : ssammudan.cotree.domain.member.type
+ * FileName    : OrderProductCategoryType
+ * Author      : kwak
+ * Date        : 2025. 4. 8.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 8.     kwak               Initial creation
+ */
+@Getter
+@AllArgsConstructor
+public enum OrderProductCategoryType {
+
+	TECH_TUBE(1L),
+	TECH_BOOK(2L);
+
+	private final Long id;
+}

--- a/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/controller/ResumeController.java
@@ -21,7 +21,7 @@ import ssammudan.cotree.domain.resume.dto.ResumeCreateRequest;
 import ssammudan.cotree.domain.resume.dto.ResumeCreateResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeDetailResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeResponse;
-import ssammudan.cotree.domain.resume.dto.SearchResumeSort;
+import ssammudan.cotree.domain.resume.type.SearchResumeSort;
 import ssammudan.cotree.domain.resume.service.ResumeService;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;

--- a/src/main/java/ssammudan/cotree/domain/resume/service/ResumeService.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/service/ResumeService.java
@@ -9,7 +9,7 @@ import ssammudan.cotree.domain.resume.dto.ResumeCreateRequest;
 import ssammudan.cotree.domain.resume.dto.ResumeCreateResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeDetailResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeResponse;
-import ssammudan.cotree.domain.resume.dto.SearchResumeSort;
+import ssammudan.cotree.domain.resume.type.SearchResumeSort;
 import ssammudan.cotree.global.response.PageResponse;
 
 /**

--- a/src/main/java/ssammudan/cotree/domain/resume/service/ResumeServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/service/ResumeServiceImpl.java
@@ -20,7 +20,7 @@ import ssammudan.cotree.domain.resume.dto.ResumeCreateRequest;
 import ssammudan.cotree.domain.resume.dto.ResumeCreateResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeDetailResponse;
 import ssammudan.cotree.domain.resume.dto.ResumeResponse;
-import ssammudan.cotree.domain.resume.dto.SearchResumeSort;
+import ssammudan.cotree.domain.resume.type.SearchResumeSort;
 import ssammudan.cotree.domain.resume.dto.query.BasicInfoQueryDto;
 import ssammudan.cotree.domain.resume.dto.query.TechStackInfo;
 import ssammudan.cotree.global.error.GlobalException;

--- a/src/main/java/ssammudan/cotree/domain/resume/type/SearchResumeSort.java
+++ b/src/main/java/ssammudan/cotree/domain/resume/type/SearchResumeSort.java
@@ -1,4 +1,4 @@
-package ssammudan.cotree.domain.resume.dto;
+package ssammudan.cotree.domain.resume.type;
 
 /**
  * PackageName : ssammudan.cotree.domain.resume.dto

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
 	MEMBER_SIGNUP_CODE_VERIFY_SUCCESS(HttpStatus.OK, "200", "회원가입 전화번호 인증 성공"),
 	MEMBER_RECOVER_CODE_SEND_SUCCESS(HttpStatus.OK, "200", "아이디 찾기 인증번호 발송 성공"),
 	MEMBER_RECOVER_CODE_VERIFY_SUCCESS(HttpStatus.OK, "200", "아이디 찾기 전화번호 인증 성공"),
+	MEMBER_ORDER_LIST_FIND_SUCCESS(HttpStatus.OK, "200", "회원의 구매 목록 조회를 성공하였습니다."),
 
 	//Education
 	TECH_BOOK_READ_SUCCESS(HttpStatus.OK, "200", "TechBook 조회를 성공했습니다."),

--- a/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepository.java
+++ b/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import ssammudan.cotree.model.member.member.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, String> {
+public interface MemberRepository extends JpaRepository<Member, String>, MemberRepositoryCustom {
 	Optional<Member> findByUsername(String username);
 
 	Optional<Member> findByEmail(String email);

--- a/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,24 @@
+package ssammudan.cotree.model.member.member.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.domain.member.dto.MemberOrderResponse;
+import ssammudan.cotree.domain.member.type.OrderProductCategoryType;
+
+/**
+ * PackageName : ssammudan.cotree.model.member.member.repository
+ * FileName    : MemberRepositoryCustom
+ * Author      : kwak
+ * Date        : 2025. 4. 8.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 8.     kwak               Initial creation
+ */
+public interface MemberRepositoryCustom {
+
+	Page<MemberOrderResponse> getOrderList(Pageable pageable, OrderProductCategoryType type, String id);
+}
+

--- a/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/ssammudan/cotree/model/member/member/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,125 @@
+package ssammudan.cotree.model.member.member.repository;
+
+import static ssammudan.cotree.domain.member.type.OrderProductCategoryType.*;
+import static ssammudan.cotree.model.education.techbook.techbook.entity.QTechBook.*;
+import static ssammudan.cotree.model.education.techtube.techtube.entity.QTechTube.*;
+import static ssammudan.cotree.model.member.member.entity.QMember.*;
+import static ssammudan.cotree.model.payment.order.category.entity.QOrderCategory.*;
+import static ssammudan.cotree.model.payment.order.history.entity.QOrderHistory.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.member.dto.MemberOrderResponse;
+import ssammudan.cotree.domain.member.type.OrderProductCategoryType;
+import ssammudan.cotree.global.error.GlobalException;
+import ssammudan.cotree.global.response.ErrorCode;
+import ssammudan.cotree.model.payment.order.category.repository.OrderCategoryRepository;
+
+/**
+ * PackageName : ssammudan.cotree.model.member.member.repository
+ * FileName    : MemberRepositoryCustomImpl
+ * Author      : kwak
+ * Date        : 2025. 4. 8.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 8.     kwak               Initial creation
+ */
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+	private final OrderCategoryRepository orderCategoryRepository;
+
+	@Override
+	public Page<MemberOrderResponse> getOrderList(Pageable pageable, OrderProductCategoryType type,
+		String memberId) {
+
+		// FK 관계 없으므로 무결성 검증 로직 진행
+		if (!orderCategoryRepository.existsById(type.getId())) {
+			throw new GlobalException(ErrorCode.ORDER_CATEGORY_NOT_FOUND);
+		}
+
+		if (type == TECH_TUBE) {
+			return getOrderTechTube(type.getId(), memberId, pageable);
+		} else {
+			return getOrderTechBook(type.getId(), memberId, pageable);
+		}
+	}
+
+	private Page<MemberOrderResponse> getOrderTechTube(Long productTypeId, String memberId, Pageable pageable) {
+		List<MemberOrderResponse> responses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					MemberOrderResponse.class,
+					orderHistory.productId,
+					orderCategory.name,
+					techTube.techTubeThumbnailUrl,
+					techTube.title,
+					techTube.description
+				))
+			.from(orderHistory)
+			.join(orderHistory.customer, member)
+			.join(orderHistory.orderCategory, orderCategory)
+			.join(techTube).on(orderHistory.productId.eq(techTube.id))
+			.where(
+				member.id.eq(memberId),
+				orderHistory.orderCategory.id.eq(productTypeId))
+			.orderBy(orderHistory.createdAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = getTotal(productTypeId, memberId);
+
+		return new PageImpl<>(responses, pageable, total != null ? total : 0);
+	}
+
+	private Page<MemberOrderResponse> getOrderTechBook(Long productTypeId, String memberId, Pageable pageable) {
+		List<MemberOrderResponse> responses = jpaQueryFactory
+			.select(
+				Projections.constructor(
+					MemberOrderResponse.class,
+					orderHistory.productId,
+					orderCategory.name,
+					techBook.techBookThumbnailUrl,
+					techBook.title,
+					techBook.description
+				))
+			.from(orderHistory)
+			.join(orderHistory.customer, member)
+			.join(orderHistory.orderCategory, orderCategory)
+			.join(techBook).on(orderHistory.productId.eq(techBook.id))
+			.where(
+				member.id.eq(memberId),
+				orderHistory.orderCategory.id.eq(productTypeId))
+			.orderBy(orderHistory.createdAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = getTotal(productTypeId, memberId);
+
+		return new PageImpl<>(responses, pageable, total != null ? total : 0);
+	}
+
+	private Long getTotal(Long productTypeId, String memberId) {
+		return jpaQueryFactory
+			.select(orderHistory.count())
+			.from(orderHistory)
+			.join(orderHistory.customer, member)
+			.where(
+				orderHistory.customer.id.eq(memberId),
+				orderHistory.orderCategory.id.eq(productTypeId))
+			.fetchOne();
+	}
+}

--- a/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDsl.java
+++ b/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDsl.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import ssammudan.cotree.domain.resume.dto.ResumeResponse;
-import ssammudan.cotree.domain.resume.dto.SearchResumeSort;
+import ssammudan.cotree.domain.resume.type.SearchResumeSort;
 
 /**
  * PackageName : ssammudan.cotree.model.recruitment.resume.resume.repository

--- a/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDslImpl.java
+++ b/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDslImpl.java
@@ -26,7 +26,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.resume.dto.ResumeResponse;
-import ssammudan.cotree.domain.resume.dto.SearchResumeSort;
+import ssammudan.cotree.domain.resume.type.SearchResumeSort;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
 


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#151 
  <br/>

## 🔎 작업 내용
- 회원이 가지고 있는 구매목록 조회
- 각 아이템 별로 상품id, 제목, 저자, 썸네일, 구매타입(TechTube/TechBook) 제공
- 구매 타입(TechTube/TeckBook/...)에 따라서 조회
- 반환된 상품id, 구매타입을 이용해 상세 조회 페이지로 이동 할 수 있다

기본 페이지 size = 12,
현재 카테고리는 techbook, techtube 입니다

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
다중 조인에 대해 고민이 많았는데, 
결국 그냥 다중 조인을 사용하고 추후에 데이터가 너무 방대해져 문제가 확인되면 
그 때 쿼리를 분리해서 날리든 뭘하든 개선하는 식으로 적용하는 것으로 답이 나왔습니다

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>