### PR TITLE
[FEAT] #PTDD-1 프로젝트 직무별 모집 인원 수정

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
+++ b/src/main/java/ssammudan/cotree/domain/project/controller/ProjectController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -25,6 +26,8 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.domain.project.dto.UpdateProjectPositionRequest;
+import ssammudan.cotree.domain.project.service.ProjectService;
 import ssammudan.cotree.domain.project.service.ProjectServiceImpl;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.global.response.BaseResponse;
@@ -48,6 +51,7 @@ import ssammudan.cotree.global.response.SuccessCode;
 @Tag(name = "Project Controller", description = "프로젝트 관련 API")
 public class ProjectController {
 	private final ProjectServiceImpl projectServiceImpl;
+	private final ProjectService projectService;
 
 	@PostMapping(value = "/", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "프로젝트 생성", description = "새로운 프로젝트를 생성합니다.")
@@ -133,6 +137,19 @@ public class ProjectController {
 		String memberId = customUser.getId();
 		projectServiceImpl.applyForProject(projectId, memberId);
 		return BaseResponse.success(SuccessCode.PROJECT_APPLY_SUCCESS);
+	}
+
+	@PatchMapping("/{projectId}/position")
+	@Operation(summary = "프로젝트 직무별 모집 인원 수정", description = "프로젝트 직무별 모집 인원을 수정합니다.")
+	@ApiResponse(responseCode = "200", description = "수정 성공")
+	public BaseResponse<Void> updateProjectPositionAmounts(
+		@PathVariable Long projectId,
+		@RequestBody List<UpdateProjectPositionRequest> requests,
+		@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = customUser.getId();
+		projectService.updateProjectPositionAmounts(projectId, memberId, requests);
+		return BaseResponse.success(SuccessCode.PROJECT_POSITION_UPDATE_SUCCESS);
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectDevPositionResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectDevPositionResponse.java
@@ -1,0 +1,28 @@
+package ssammudan.cotree.domain.project.dto;
+
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : ProjectDevPositionResponse
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 9.
+ * Description : ProjectDevPositionResponse
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 9.     sangxxjin               Initial creation
+ */
+public record ProjectDevPositionResponse(
+	Long projectDevPositionId,
+	String positionName,
+	int amount
+) {
+	public static ProjectDevPositionResponse from(ProjectDevPosition devPosition) {
+		return new ProjectDevPositionResponse(
+			devPosition.getId(),
+			devPosition.getDevelopmentPosition().getName(),
+			devPosition.getAmount()
+		);
+	}
+}

--- a/src/main/java/ssammudan/cotree/domain/project/dto/ProjectInfoResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/ProjectInfoResponse.java
@@ -2,7 +2,6 @@ package ssammudan.cotree.domain.project.dto;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,7 +28,7 @@ public record ProjectInfoResponse(
 	LocalDate startDate,
 	LocalDate endDate,
 	String contact,
-	List<Map<String, Integer>> devPositionsInfo,
+	List<ProjectDevPositionResponse> devPositionsInfo,
 	List<String> techStacks,
 	String partnerType,
 	int viewCount,
@@ -43,7 +42,7 @@ public record ProjectInfoResponse(
 		Project project,
 		Member creator,
 		long likeCount,
-		List<Map<String, Integer>> devPositionsInfo,
+		List<ProjectDevPositionResponse> devPositionsInfo,
 		List<String> techStacks,
 		boolean isLiked,
 		boolean isParticipant,

--- a/src/main/java/ssammudan/cotree/domain/project/dto/UpdateProjectPositionRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/project/dto/UpdateProjectPositionRequest.java
@@ -1,0 +1,18 @@
+package ssammudan.cotree.domain.project.dto;
+
+/**
+ * PackageName : ssammudan.cotree.domain.project.dto
+ * FileName    : UpdateProjectPositionRequest
+ * Author      : sangxxjin
+ * Date        : 2025. 4. 9.
+ * Description : UpdateProjectPositionRequest
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025. 4. 9.     sangxxjin               Initial creation
+ */
+public record UpdateProjectPositionRequest(
+	Long projectDevPositionId,
+	Integer amount
+) {
+}

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectService.java
@@ -9,6 +9,7 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.domain.project.dto.UpdateProjectPositionRequest;
 import ssammudan.cotree.global.response.PageResponse;
 
 /**
@@ -40,4 +41,6 @@ public interface ProjectService {
 	void updateRecruitmentStatus(Long projectId, String memberId);
 
 	void applyForProject(Long projectId, String memberId);
+
+	void updateProjectPositionAmounts(Long projectId, String memberId, List<UpdateProjectPositionRequest> requests);
 }

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -3,6 +3,7 @@ package ssammudan.cotree.domain.project.service;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +17,7 @@ import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.domain.project.dto.UpdateProjectPositionRequest;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.global.response.PageResponse;
@@ -152,6 +154,37 @@ public class ProjectServiceImpl implements ProjectService {
 			throw new GlobalException(ErrorCode.PROJECT_MEMBER_ALREADY_EXISTS);
 		ProjectMembership projectMembership = ProjectMembership.builderForApply(project, getMemberOrThrow(memberId));
 		projectMembershipRepository.save(projectMembership);
+	}
+
+	@Override
+	@Transactional
+	public void updateProjectPositionAmounts(Long projectId, String memberId,
+		List<UpdateProjectPositionRequest> requests) {
+		Project project = getProjectOrThrow(projectId);
+		if (Boolean.FALSE.equals(project.getIsOpen()))
+			throw new GlobalException(ErrorCode.PROJECT_NOT_OPEN);
+		if (!isProjectOwner(project, memberId))
+			throw new GlobalException(ErrorCode.PROJECT_OWNER_ONLY);
+
+		List<ProjectDevPosition> currentPositions = projectRepository.findAllByProjectId(projectId);
+
+		Map<Long, ProjectDevPosition> currentMap = currentPositions.stream()
+			.collect(Collectors.toMap(ProjectDevPosition::getId, p -> p));
+
+		Set<Long> requestIds = requests.stream()
+			.map(UpdateProjectPositionRequest::projectDevPositionId)
+			.collect(Collectors.toSet());
+
+		for (ProjectDevPosition existing : currentPositions) {
+			if (!requestIds.contains(existing.getId())) {
+				projectDevPositionRepository.delete(existing);
+			}
+		}
+
+		for (UpdateProjectPositionRequest req : requests) {
+			ProjectDevPosition position = currentMap.get(req.projectDevPositionId());
+			position.updateAmount(req.amount());
+		}
 	}
 
 	private Project getProjectByIdAndOptionalMemberId(Long projectId, String memberId) {

--- a/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/project/service/ProjectServiceImpl.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import ssammudan.cotree.domain.project.dto.ProjectCreateRequest;
 import ssammudan.cotree.domain.project.dto.ProjectCreateResponse;
+import ssammudan.cotree.domain.project.dto.ProjectDevPositionResponse;
 import ssammudan.cotree.domain.project.dto.ProjectInfoResponse;
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.domain.project.dto.UpdateProjectPositionRequest;
@@ -204,9 +205,9 @@ public class ProjectServiceImpl implements ProjectService {
 		return developmentPositionRepository.findByIds(request.recruitmentPositions().keySet());
 	}
 
-	private List<Map<String, Integer>> convertDevPositions(Set<ProjectDevPosition> devPositions) {
+	private List<ProjectDevPositionResponse> convertDevPositions(Set<ProjectDevPosition> devPositions) {
 		return devPositions.stream()
-			.map(devPos -> Map.of(devPos.getDevelopmentPosition().getName(), devPos.getAmount()))
+			.map(ProjectDevPositionResponse::from)
 			.toList();
 	}
 

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -45,6 +45,7 @@ public enum SuccessCode {
 	PROJECT_FETCH_SUCCESS(HttpStatus.OK, "200", "프로젝트 상세 조회 성공"),
 	PROJECT_STATUS_UPDATE_SUCCESS(HttpStatus.OK, "200", "프로젝트 모집 상태 변경 성공"),
 	PROJECT_APPLY_SUCCESS(HttpStatus.OK, "200", "프로젝트 참가 신청 성공"),
+	PROJECT_POSITION_UPDATE_SUCCESS(HttpStatus.OK, "200", "프로젝트 직무별 모집 인원 수정 성공"),
 
 	//Community
 	COMMUNITY_BOARD_CREATE_SUCCESS(HttpStatus.CREATED, "201", "글 작성 성공"),

--- a/src/main/java/ssammudan/cotree/model/project/devposition/entity/ProjectDevPosition.java
+++ b/src/main/java/ssammudan/cotree/model/project/devposition/entity/ProjectDevPosition.java
@@ -60,4 +60,8 @@ public class ProjectDevPosition {
 			.amount(amount)
 			.build();
 	}
+
+	public void updateAmount(Integer amount) {
+		this.amount = amount;
+	}
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
 import ssammudan.cotree.model.project.project.entity.Project;
 
 /**
@@ -31,4 +32,6 @@ public interface ProjectRepositoryCustom {
 
 	Page<ProjectListResponse> findByFilters(Pageable pageable, List<Long> techStackIds,
 		List<Long> devPositionIds, String sort);
+
+	List<ProjectDevPosition> findAllByProjectId(Long projectId);
 }

--- a/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/project/project/repository/ProjectRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import ssammudan.cotree.domain.project.dto.ProjectListResponse;
 import ssammudan.cotree.model.common.like.entity.QLike;
+import ssammudan.cotree.model.project.devposition.entity.ProjectDevPosition;
 import ssammudan.cotree.model.project.devposition.entity.QProjectDevPosition;
 import ssammudan.cotree.model.project.membership.entity.QProjectMembership;
 import ssammudan.cotree.model.project.project.entity.Project;
@@ -131,6 +132,16 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 		List<ProjectListResponse> content = projectQueryHelper.convertToDtoOrdered(projects, sortedIds);
 
 		return new PageImpl<>(content, pageable, filteredProjectIds.size());
+	}
+
+	@Override
+	public List<ProjectDevPosition> findAllByProjectId(Long projectId) {
+		QProjectDevPosition pdp = QProjectDevPosition.projectDevPosition;
+
+		return queryFactory
+			.selectFrom(pdp)
+			.where(pdp.project.id.eq(projectId))
+			.fetch();
 	}
 
 	private JPAQuery<Project> baseProjectJoinQuery() {


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#168 
  <br/>

## 🔎 작업 내용
- 프로젝트 상세 조회에서 직무별 모집 인원을 수정하게 구현했습니다.
  - 프로젝트는 모집중이어야하고 생성자만 수정이 가능합니다.
- 직무별 모집 인원 수정을 위해 프로젝트 상세조회에서 projectDevPositionId도 추가하여 전달하였습니다.

  <br/>