### PR TITLE
[FEAT] 프론트엔드 서버 URL CORS 허용 경로 추가

### DIFF
--- a/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
+++ b/src/main/java/ssammudan/cotree/global/config/SecurityConfig.java
@@ -139,7 +139,7 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 허용할 오리진 설정
 		configuration.setAllowedOrigins(
-			List.of(frontendConfig.getFrontendUrl())); // 프론트 엔드
+			frontendConfig.getFrontendUrls()); // 프론트 엔드
 		// 허용할 HTTP 메서드 설정
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")); // 프론트 엔드 허용 메서드
 		// 자격 증명 허용 설정

--- a/src/main/java/ssammudan/cotree/global/config/security/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/ssammudan/cotree/global/config/security/oauth/handler/OAuth2FailureHandler.java
@@ -34,7 +34,7 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException, ServletException {
 		log.error("OAuth2 인증 실패 : {}", exception.getMessage());
-		String frontendUrl = frontendConfig.getFrontendUrl();
+		String frontendUrl = frontendConfig.getPrimaryFrontendUrl();
 
 		response.sendRedirect(frontendUrl + "/login/callback?error=true");
 	}

--- a/src/main/java/ssammudan/cotree/global/config/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/ssammudan/cotree/global/config/security/oauth/handler/OAuth2SuccessHandler.java
@@ -40,7 +40,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		Authentication authentication)
 		throws IOException, ServletException {
 
-		String frontendUrl = frontendConfig.getFrontendUrl();
+		String frontendUrl = frontendConfig.getPrimaryFrontendUrl();
 
 		CustomUser loginUser = (CustomUser)authentication.getPrincipal();
 

--- a/src/main/java/ssammudan/cotree/infra/frontend/FrontendConfig.java
+++ b/src/main/java/ssammudan/cotree/infra/frontend/FrontendConfig.java
@@ -1,5 +1,8 @@
 package ssammudan.cotree.infra.frontend;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,11 +18,21 @@ import lombok.Getter;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 4. 2.     hc               Initial creation
+ * 25. 4.10.     sangxxjin        여러 url 전달하게 수정 및 primary url 제공
  */
-
+@Getter
 @Configuration
 public class FrontendConfig {
-	@Getter
-	@Value("${frontend.url}")
-	private String frontendUrl;
+
+	private final List<String> frontendUrls;
+
+	public FrontendConfig(@Value("${frontend.url}") String frontendUrl) {
+		this.frontendUrls = Arrays.stream(frontendUrl.split(","))
+			.map(String::trim)
+			.toList();
+	}
+
+	public String getPrimaryFrontendUrl() {
+		return frontendUrls.getFirst();
+	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#184 
  <br/>

## 🔎 작업 내용
- `.env` 파일에 프론트엔드 서버 도메인(`FRONTEND_URL`) 추가  
- `FrontendConfig`: 다중 URL 반환 가능하도록 수정 (`,`로 구분)  
- OAuth2 핸들러에서 redirect URL 추출 방식 변경 (서버용 URL 대응)
- CORS 설정에 프론트 서버 도메인 추가 (로컬, 배포 환경 모두 허용)  
- Notion에 `.env` 파일 적용 내용 문서화 완료  

  <br/>
  
##  💬 집중 리뷰 요구
- oauth redirect url => 기존의 로컬 url -> 서버 url로 변경했는데 괜찮을까요?