### PR TITLE
[BUG] : Redis 저장 결제 정보 시간 단위 수정

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
@@ -73,7 +73,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 		PrePaymentValue value = PrePaymentValue.of(memberId, prePaymentInfo);
 
-		redisTemplate.opsForValue().set(redisKey, value, Duration.ofMillis(MAX_RETENTION_TIME));
+		redisTemplate.opsForValue().set(redisKey, value, Duration.ofMinutes(MAX_RETENTION_TIME));
 
 		return prePaymentInfo;
 	}


### PR DESCRIPTION
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
close #191 
  <br/>

## 🔎 작업 내용
- 결제 전 Redis에 저장해놓는 결제 정보 유지 시간 단위가 리팩토링 과정 중 millis로 적용됨
- 기존 의도(10분 유지) 적용을 위해 minute로 수정

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>