### PR TITLE
[BUG] 결제 로직 중 Redis 저장 데이터 역직렬화 에러 등 수정

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/order/facade/OrderFacade.java
+++ b/src/main/java/ssammudan/cotree/domain/order/facade/OrderFacade.java
@@ -20,6 +20,7 @@ import ssammudan.cotree.infra.payment.dto.ApiPaymentRequest;
 import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.payment.order.category.entity.OrderCategory;
 import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
+import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 
 /**
  * PackageName : ssammudan.cotree.domain.order.facade
@@ -87,7 +88,16 @@ public class OrderFacade {
 			member, orderCategory, tossPaymentRequest.getPaymentKey(), verifiedValue
 		);
 
-		return paymentService.confirmPaymentRequest(redisKey, tossPaymentRequest, orderHistory);
+		PaymentResponse.Detail response;
+		try {
+			response = paymentService.confirmPaymentRequest(redisKey, tossPaymentRequest);
+			orderHistoryService.updateStatus(orderHistory, response.paymentStatus());
+		} catch (Exception e) {
+			orderHistoryService.updateStatus(orderHistory, PaymentStatus.FAILED);
+			throw e;
+		}
+
+		return response;
 	}
 
 	/**

--- a/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryService.java
+++ b/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryService.java
@@ -4,6 +4,7 @@ import ssammudan.cotree.domain.payment.dto.PrePaymentValue;
 import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.payment.order.category.entity.OrderCategory;
 import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
+import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 
 /**
  * PackageName : ssammudan.cotree.domain.order.service
@@ -21,5 +22,7 @@ public interface OrderHistoryService {
 	OrderHistory createOrderHistory(
 		Member member, OrderCategory orderCategory, String paymentKey, PrePaymentValue prePaymentValue
 	);
+
+	void updateStatus(OrderHistory orderHistory, PaymentStatus status);
 
 }

--- a/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
@@ -1,6 +1,7 @@
 package ssammudan.cotree.domain.order.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import ssammudan.cotree.model.member.member.entity.Member;
 import ssammudan.cotree.model.payment.order.category.entity.OrderCategory;
 import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
 import ssammudan.cotree.model.payment.order.history.repository.OrderHistoryRepository;
+import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 
 /**
  * PackageName : ssammudan.cotree.domain.order.service
@@ -44,6 +46,13 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
 			prePaymentValue.info().productName(),
 			prePaymentValue.info().amount()
 		));
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Override
+	public void updateStatus(final OrderHistory orderHistory, final PaymentStatus status) {
+		orderHistory.modifyStatus(status);
+		orderHistoryRepository.save(orderHistory);
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
@@ -35,7 +35,7 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
 		final String paymentKey,
 		final PrePaymentValue prePaymentValue
 	) {
-		return OrderHistory.create(
+		return orderHistoryRepository.save(OrderHistory.create(
 			member,
 			orderCategory,
 			prePaymentValue.info().orderId(),
@@ -43,7 +43,7 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
 			prePaymentValue.info().itemId(),
 			prePaymentValue.info().productName(),
 			prePaymentValue.info().amount()
-		);
+		));
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/order/service/OrderHistoryServiceImpl.java
@@ -29,7 +29,7 @@ public class OrderHistoryServiceImpl implements OrderHistoryService {
 
 	private final OrderHistoryRepository orderHistoryRepository;
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	@Override
 	public OrderHistory createOrderHistory(
 		final Member member,

--- a/src/main/java/ssammudan/cotree/domain/payment/controller/PaymentController.java
+++ b/src/main/java/ssammudan/cotree/domain/payment/controller/PaymentController.java
@@ -51,10 +51,10 @@ public class PaymentController {
 		@RequestBody @Valid final PaymentRequest.PrePayment requestDto,
 		@AuthenticationPrincipal final UserDetails userDetails
 	) {
-		PaymentResponse.PrePaymentInfo resopnseDt = orderFacade.savePrePayment(
+		PaymentResponse.PrePaymentInfo responseDto = orderFacade.savePrePayment(
 			requestDto, ((CustomUser)userDetails).getId()
 		);
-		return BaseResponse.success(SuccessCode.PRE_PAYMENT_SAVE_SUCCESS, resopnseDt);
+		return BaseResponse.success(SuccessCode.PRE_PAYMENT_SAVE_SUCCESS, responseDto);
 	}
 
 	@GetMapping("/confirm")
@@ -69,6 +69,7 @@ public class PaymentController {
 		PaymentResponse.Detail responseDto = orderFacade.confirmPayment(
 			TossPaymentRequest.of(paymentKey, amount, orderId), ((CustomUser)userDetails).getId()
 		);
+
 		return BaseResponse.success(SuccessCode.TOSS_PAYMENT_SUCCESS, responseDto);
 	}
 

--- a/src/main/java/ssammudan/cotree/domain/payment/service/PaymentService.java
+++ b/src/main/java/ssammudan/cotree/domain/payment/service/PaymentService.java
@@ -6,7 +6,6 @@ import ssammudan.cotree.domain.payment.dto.PaymentRequest;
 import ssammudan.cotree.domain.payment.dto.PaymentResponse;
 import ssammudan.cotree.domain.payment.dto.PrePaymentValue;
 import ssammudan.cotree.domain.payment.dto.TossPaymentRequest;
-import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
 
 /**
  * PackageName : ssammudan.cotree.domain.payment.service
@@ -31,8 +30,6 @@ public interface PaymentService {
 
 	PrePaymentValue verifyPayment(String redisKey, TossPaymentRequest request, String memberId);
 
-	PaymentResponse.Detail confirmPaymentRequest(
-		String redisKey, TossPaymentRequest request, OrderHistory orderHistory
-	);
+	PaymentResponse.Detail confirmPaymentRequest(String redisKey, TossPaymentRequest request);
 
 }

--- a/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
@@ -2,7 +2,6 @@ package ssammudan.cotree.domain.payment.service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -20,7 +19,6 @@ import ssammudan.cotree.domain.payment.dto.TossPaymentResponse;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.infra.payment.toss.TossPaymentClient;
-import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
 import ssammudan.cotree.model.payment.order.type.PaymentStatus;
 
 /**
@@ -112,49 +110,27 @@ public class PaymentServiceImpl implements PaymentService {
 	 *
 	 * @param redisKey     - Redis 키
 	 * @param request      - 토스 결제 정보 요청 DTO
-	 * @param orderHistory - OrderHistory 엔티티
 	 * @return PaymentResponse Detail DTO
 	 */
 	@Override
-	public PaymentResponse.Detail confirmPaymentRequest(
-		final String redisKey, final TossPaymentRequest request, final OrderHistory orderHistory
-	) {
+	public PaymentResponse.Detail confirmPaymentRequest(final String redisKey, final TossPaymentRequest request) {
 		try {
 			TossPaymentResponse tossPaymentResponse = (TossPaymentResponse)tossPaymentClient.confirmPayment(
 				request
 			);
-			orderHistory.modifyStatus(PaymentStatus.SUCCESS);
-
 			return PaymentResponse.Detail.from(tossPaymentResponse, PaymentStatus.SUCCESS);
 		} catch (GlobalException e) {
-			if (e.getErrorCode() == ErrorCode.TOSS_API_ERROR) {
-				log.error("Toss API Error", e.getMessage());
-			} else if (e.getErrorCode() == ErrorCode.TOSS_API_TIMEOUT) {
-				log.error("Toss API Timeout", e.getMessage());
-			}
-			orderHistory.modifyStatus(PaymentStatus.FAILED);
+			throw e;
 		} catch (Exception e) {
 			log.error("Unexpected error calling Toss API", e);
-			orderHistory.modifyStatus(PaymentStatus.FAILED);
+			throw e;
 		} finally {
 			try {
-				deletePrePayment(redisKey);
+				redisTemplate.delete(redisKey);
 			} catch (Exception e) {
 				log.warn("Failed to delete Redis pre-payment info. key: {}", redisKey, e);
 			}
 		}
-
-		return PaymentResponse.Detail.of(
-			orderHistory.getOrderId(),
-			orderHistory.getProductName(),
-			orderHistory.getPrice(),
-			LocalDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME),
-			PaymentStatus.FAILED
-		);
-	}
-
-	private void deletePrePayment(final String redisKey) {
-		redisTemplate.delete(redisKey);
 	}
 
 }

--- a/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/payment/service/PaymentServiceImpl.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ssammudan.cotree.domain.payment.dto.PaymentRequest;
@@ -17,7 +19,6 @@ import ssammudan.cotree.domain.payment.dto.TossPaymentRequest;
 import ssammudan.cotree.domain.payment.dto.TossPaymentResponse;
 import ssammudan.cotree.global.error.GlobalException;
 import ssammudan.cotree.global.response.ErrorCode;
-import ssammudan.cotree.infra.payment.PaymentClient;
 import ssammudan.cotree.infra.payment.toss.TossPaymentClient;
 import ssammudan.cotree.model.payment.order.history.entity.OrderHistory;
 import ssammudan.cotree.model.payment.order.type.PaymentStatus;
@@ -41,7 +42,7 @@ public class PaymentServiceImpl implements PaymentService {
 	private static final long MAX_RETENTION_TIME = 10;    //서버 내 결제 정보 저장 유지 시간
 
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final PaymentClient paymentClient;
+	private final ObjectMapper objectMapper;
 	private final TossPaymentClient tossPaymentClient;
 
 	/**
@@ -89,7 +90,9 @@ public class PaymentServiceImpl implements PaymentService {
 	public PrePaymentValue verifyPayment(
 		final String redisKey, final TossPaymentRequest request, final String memberId
 	) {
-		PrePaymentValue value = (PrePaymentValue)redisTemplate.opsForValue().get(redisKey);
+		PrePaymentValue value = objectMapper.convertValue(
+			redisTemplate.opsForValue().get(redisKey), PrePaymentValue.class
+		);
 
 		if (value == null) {
 			throw new GlobalException(ErrorCode.PAYMENT_EXPIRED_PREPAYMENT);


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
close #195 
  <br/>

## 🔎 작업 내용
- Redis에 저장된 검증용 결제 데이터를 역직렬화하여 조회할 때 타입 캐스팅 문제 해결
- OrderHistory 생성 및 상태 반영 저장(결제 성공 or 결제 실패) 트랜잭션 분리
  - 결제 승인 API 호출 예외 발생 시에도 결제 기록은 DB에 반드시 저장하기 위함
- 기타 코드 리팩토링

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>