### PR TITLE
[FEAT] #CBL-1 커뮤니티 좋아요 글 목록 조회

### DIFF
--- a/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
+++ b/src/main/java/ssammudan/cotree/domain/community/controller/CommunityController.java
@@ -37,6 +37,7 @@ import ssammudan.cotree.global.response.SuccessCode;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-28     Baekgwa               Initial creation
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 @RestController
 @RequestMapping("/api/v1/community")
@@ -110,5 +111,20 @@ public class CommunityController {
 		String memberId = customUser.getId();
 		communityService.deleteBoard(boardId, memberId);
 		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_DELETE_SUCCESS);
+	}
+
+	@GetMapping("/like")
+	@Operation(summary = "커뮤니티 글 중, 내가 좋아요(관심) 목록 조회")
+	public BaseResponse<PageResponse<CommunityResponse.BoardLikeListDetail>> getLikeBoardList(
+		@RequestParam(value = "page", defaultValue = "0", required = false) int page,
+		@RequestParam(value = "size", defaultValue = "16", required = false) int size,
+		@AuthenticationPrincipal CustomUser customUser
+	) {
+		String memberId = customUser.getId();
+		Pageable pageable = PageRequest.of(page, size);
+		PageResponse<CommunityResponse.BoardLikeListDetail> boardLikeList =
+			communityService.getBoardLikeList(pageable, memberId);
+
+		return BaseResponse.success(SuccessCode.COMMUNITY_BOARD_LIKE_SEARCH_SUCCESS, boardLikeList);
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityResponse.java
@@ -20,6 +20,7 @@ import lombok.With;
  * 2025-03-31     Baekgwa               Initial creation
  * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
  * 2025-04-08     Baekgwa               목록, 상세 조회 시, 작성자의 프로필 이미지 return 추가
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 public class CommunityResponse {
 
@@ -54,5 +55,8 @@ public class CommunityResponse {
 		public static BoardCreate of(Long boardId) {
 			return new BoardCreate(boardId);
 		}
+	}
+
+	public record BoardLikeListDetail(Long id, String title, String author, LocalDateTime createdAt, String content, String thumbnailImage) {
 	}
 }

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityService.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityService.java
@@ -18,6 +18,7 @@ import ssammudan.cotree.global.response.PageResponse;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-03-28     Baekgwa               Initial creation
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 public interface CommunityService {
 	CommunityResponse.BoardCreate createNewBoard(final CommunityRequest.CreateBoard createBoard, final String memberId);
@@ -34,4 +35,9 @@ public interface CommunityService {
 	void modifyBoard(final Long boardId, final CommunityRequest.ModifyBoard modifyBoard, final String memberId);
 
 	void deleteBoard(final Long boardId, final String memberId);
+
+	PageResponse<CommunityResponse.BoardLikeListDetail> getBoardLikeList(
+		final Pageable pageable,
+		final String memberId
+	);
 }

--- a/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/ssammudan/cotree/domain/community/service/CommunityServiceImpl.java
@@ -20,6 +20,7 @@ import ssammudan.cotree.global.response.ErrorCode;
 import ssammudan.cotree.global.response.PageResponse;
 import ssammudan.cotree.infra.viewcount.persistence.ViewCountStore;
 import ssammudan.cotree.infra.viewcount.type.ViewCountType;
+import ssammudan.cotree.model.common.like.repository.LikeRepository;
 import ssammudan.cotree.model.community.category.entity.CommunityCategory;
 import ssammudan.cotree.model.community.category.repository.CommunityCategoryRepository;
 import ssammudan.cotree.model.community.community.entity.Community;
@@ -40,6 +41,7 @@ import ssammudan.cotree.model.member.member.repository.MemberRepository;
  * 2025-04-04     Baekgwa               글 수정/삭제 기능 추가
  * 2025-04-07     Baekgwa               Thumbnail 이미지 출력 정상화
  * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 @Service
 @RequiredArgsConstructor
@@ -49,6 +51,7 @@ public class CommunityServiceImpl implements CommunityService {
 	private final CommunityRepository communityRepository;
 	private final MemberRepository memberRepository;
 	private final ViewCountStore viewCountStore;
+	private final LikeRepository likeRepository;
 
 	@Transactional
 	@Override
@@ -166,6 +169,14 @@ public class CommunityServiceImpl implements CommunityService {
 
 		// 현재 글삭제는 하드 delete
 		communityRepository.deleteById(boardId);
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public PageResponse<CommunityResponse.BoardLikeListDetail> getBoardLikeList(
+		Pageable pageable, String memberId
+	) {
+		return PageResponse.of(likeRepository.findBoardLikeList(pageable, memberId));
 	}
 
 	/**

--- a/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
+++ b/src/main/java/ssammudan/cotree/global/response/SuccessCode.java
@@ -56,6 +56,7 @@ public enum SuccessCode {
 	COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS(HttpStatus.OK, "200", "커뮤니티 글 상세 조회 성공"),
 	COMMUNITY_BOARD_MODIFY_SUCCESS(HttpStatus.OK, "200", "커뮤니티 글 수정 성공"),
 	COMMUNITY_BOARD_DELETE_SUCCESS(HttpStatus.OK, "200", "커뮤니티 글 삭제 성공"),
+	COMMUNITY_BOARD_LIKE_SEARCH_SUCCESS(HttpStatus.OK, "200", "내 좋아요 커뮤니티 글 조회 성공"),
 
 	//S3 Upload
 	S3_FILE_UPLOAD_SUCCESS(HttpStatus.CREATED, "201", "파일 업로드 성공."),

--- a/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryCustom.java
+++ b/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryCustom.java
@@ -1,5 +1,10 @@
 package ssammudan.cotree.model.common.like.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import ssammudan.cotree.domain.community.dto.CommunityResponse;
+
 /**
  * PackageName : ssammudan.cotree.model.common.like.repository
  * FileName    : LikeRepositoryCustom
@@ -10,6 +15,12 @@ package ssammudan.cotree.model.common.like.repository;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 4. 2.     loadingKKamo21       Initial creation
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 public interface LikeRepositoryCustom {
+
+	Page<CommunityResponse.BoardLikeListDetail> findBoardLikeList(
+		final Pageable pageable,
+		final String memberId
+	);
 }

--- a/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryImpl.java
+++ b/src/main/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryImpl.java
@@ -1,10 +1,20 @@
 package ssammudan.cotree.model.common.like.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.community.dto.CommunityResponse;
+import ssammudan.cotree.model.common.like.entity.QLike;
+import ssammudan.cotree.model.community.community.entity.QCommunity;
+import ssammudan.cotree.model.member.member.entity.QMember;
 
 /**
  * PackageName : ssammudan.cotree.model.common.like.repository
@@ -16,11 +26,52 @@ import lombok.RequiredArgsConstructor;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 25. 4. 2.     loadingKKamo21       Initial creation
+ * 2025-04-11     Baekgwa               내가 좋아요 (관심)한, Community 목록 조회 기능 추가
  */
 @Repository
 @RequiredArgsConstructor
 public class LikeRepositoryImpl implements LikeRepositoryCustom {
 
 	private final JPAQueryFactory jpaQueryFactory;
+	private static final QCommunity community = QCommunity.community;
+	private static final QLike like = QLike.like;
+	private static final QMember member = QMember.member;
 
+	@Override
+	public Page<CommunityResponse.BoardLikeListDetail> findBoardLikeList(
+		Pageable pageable, String memberId) {
+
+		List<CommunityResponse.BoardLikeListDetail> content = jpaQueryFactory
+			.select(Projections.constructor(CommunityResponse.BoardLikeListDetail.class,
+				community.id,
+				community.title,
+				member.nickname,
+				community.createdAt,
+				community.content,
+				community.thumbnailImage
+			))
+			.from(like)
+			.join(community).on(community.id.eq(like.community.id))
+			.join(member).on(member.id.eq(like.member.id))
+			.where(
+				like.member.id.eq(memberId),
+				like.community.id.isNotNull()
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(like.createdAt.desc())
+			.fetch();
+
+		// Count 쿼리
+		Long total = jpaQueryFactory
+			.select(like.count())
+			.from(like)
+			.where(
+				like.member.id.eq(memberId),
+				like.community.id.isNotNull()
+			)
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, total != null ? total : 0);
+	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#192 
  <br/>

## 🔎 작업 내용
- 내가 좋아요한 Community 목록을 조회하는 기능 구현
- 페이지네이션 응답이고, default size 는 16 입니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- 조회 시작 테이블을, `community` 에서 진행할까, `like` 에서 진행할까 고민이 되었는데, `like` 에서 시작하게 되었습니다.
- 이유는, like entity 쪽이, `회원이 좋아요 누른 커뮤니티 게시글들` 을 조회하는 목적과 책임에 더 어울린다고 판단되었습니다.

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>