### PR TITLE
[TEST] Community test code 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'ssammudan'
@@ -121,3 +122,63 @@ clean {
     }
 }
 // Querydsl generated directory setting - end
+
+
+// Jacoco - start
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.named('test') {
+    finalizedBy 'jacocoTestReport'
+}
+
+tasks.named('jacocoTestReport') {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+jacocoTestReport {
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            '**/global/**',
+                            '**/infra/**',
+                            '**/CoTreeApplication*'
+                    ])
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = false
+//            element = 'CLASS'
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = [
+                    '**/global/**',
+                    '**/infra/**',
+                    '**/CoTreeApplication*'
+            ]
+        }
+    }
+}
+
+// Jacoco - end

--- a/src/main/java/ssammudan/cotree/domain/community/dto/CommunityRequest.java
+++ b/src/main/java/ssammudan/cotree/domain/community/dto/CommunityRequest.java
@@ -18,10 +18,8 @@ import ssammudan.cotree.domain.community.dto.valid.CommunityTitle;
  * 2025-03-28     Baekgwa               Initial creation
  * 2025-04-08     Baekgwa               커뮤니티 글 작성 시, community category 입력 형식 변경. 기존 : String / 변경 : Long id
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommunityRequest {
-
-	private CommunityRequest() {
-	}
 
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/test/java/ssammudan/cotree/domain/community/controller/CommunityControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/community/controller/CommunityControllerTest.java
@@ -1,88 +1,246 @@
-// package ssammudan.cotree.domain.community.controller;
-//
-// import java.util.List;
-//
-// import org.jetbrains.annotations.NotNull;
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.transaction.annotation.Transactional;
-//
-// import ssammudan.cotree.domain.community.dto.CommunityRequest;
-// import ssammudan.cotree.integration.SpringBootTestSupporter;
-// import ssammudan.cotree.integration.security.WithCustomUser;
-// import ssammudan.cotree.model.community.category.entity.CommunityCategory;
-//
-// /**
-//  * PackageName : ssammudan.cotree.domain.community.controller
-//  * FileName    : CommunityControllerTest
-//  * Author      : Baekgwa
-//  * Date        : 2025-03-28
-//  * Description : Community Domain Controller Layer Test
-//  * =====================================================================================================================
-//  * DATE          AUTHOR               NOTE
-//  * ---------------------------------------------------------------------------------------------------------------------
-//  * 2025-03-28     Baekgwa               Initial creation
-//  */
-// @Transactional
-// class CommunityControllerTest extends SpringBootTestSupporter {
-//
-// 	private static final String THUMBNAIL_IMAGE_URL = "https://테스트_가상_이미지_url1.jpg";
-// 	private static final String NOT_THUMBNAIL_IMAGE_URL = "https://테스트_가상_이미지_url2.jpg";
-//
-// 	@WithCustomUser
-// 	@DisplayName("새로운 커뮤니티 글 작성")
-// 	@Test
-// 	void createNewBoard() throws Exception {
-// 		// given
-// 		List<CommunityCategory> savedCommunityCategoryList =
-// 			communityDataFactory.createAndSaveCommunityCategory();
-//
-// 		CommunityCategory savedCommunityCategory = savedCommunityCategoryList.getFirst();
-// 		Long communityCategoryId = savedCommunityCategory.getId();
-//
-// 		String newTitle = "새글 제목";
-// 		String newContent = createNewMarkdownContent(true);
-// 		CommunityRequest.CreateBoard createBoard =
-// 			new CommunityRequest.CreateBoard(communityCategoryId, newTitle, newContent);
-//
-// 		// when
-// 		ResultActions perform = mockMvc.perform(post("/api/v1/community/board")
-// 			.contentType(MediaType.APPLICATION_JSON)
-// 			.content(objectMapper.writeValueAsString(createBoard)));
-//
-// 		// then
-// 		perform.andDo(print())
-// 			.andExpect(status().isCreated())
-// 			.andExpect(jsonPath("$.isSuccess").value(true))
-// 			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS.getMessage()))
-// 			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS.getCode()))
-// 			.andExpect(jsonPath("$.data.boardId").isNotEmpty());
-// 	}
-//
-// 	private @NotNull String createNewMarkdownContent(final boolean isImageExist) {
-// 		String content = """
-// 			# 새글 제목
-// 			이것은 **마크다운(Markdown)** 형식으로 작성된 글입니다.
-// 			## 주요 내용
-// 			- 첫 번째 리스트 아이템
-// 			- 두 번째 리스트 아이템
-// 			- 세 번째 리스트 아이템
-// 			### 코드 블록
-// 			```java
-// 			public static void main(String[] args) {
-// 			    System.out.println("Hello, Markdown!");
-// 			}
-// 			```
-// 			""";
-//
-// 		if (isImageExist) {
-// 			content =
-// 				content + markDownImageBuilder(THUMBNAIL_IMAGE_URL) + markDownImageBuilder(NOT_THUMBNAIL_IMAGE_URL);
-// 		}
-// 		return content;
-// 	}
-//
-// 	private @NotNull String markDownImageBuilder(String imageUrl) {
-// 		return String.format("%n![이미지](%s)%n", imageUrl);
-// 	}
-// }
+package ssammudan.cotree.domain.community.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import ssammudan.cotree.domain.community.dto.CommunityRequest;
+import ssammudan.cotree.global.response.SuccessCode;
+import ssammudan.cotree.integration.SpringBootTestSupporter;
+import ssammudan.cotree.integration.security.WithCustomMember;
+import ssammudan.cotree.model.community.category.entity.CommunityCategory;
+import ssammudan.cotree.model.community.community.entity.Community;
+import ssammudan.cotree.model.member.member.entity.Member;
+
+/**
+ * PackageName : ssammudan.cotree.domain.community.controller
+ * FileName    : CommunityControllerTest
+ * Author      : Baekgwa
+ * Date        : 2025-03-28
+ * Description : Community Domain Controller Layer Test
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-03-28     Baekgwa               Initial creation
+ */
+@Transactional
+class CommunityControllerTest extends SpringBootTestSupporter {
+
+	@AfterEach
+	void tearDown() {
+		memberRepository.deleteAll();
+	}
+
+	@WithCustomMember
+	@DisplayName("새로운 커뮤니티 글 작성")
+	@Test
+	void createNewBoard1() throws Exception {
+		// given
+		List<CommunityCategory> savedCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+
+		CommunityCategory savedCommunityCategory = savedCommunityCategoryList.getFirst();
+		Long communityCategoryId = savedCommunityCategory.getId();
+
+		CommunityRequest.CreateBoard createBoard =
+			new CommunityRequest.CreateBoard(communityCategoryId, "title", "content");
+
+		// when
+		ResultActions perform = mockMvc.perform(post("/api/v1/community/board")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createBoard)));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_CREATE_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.boardId").isNotEmpty());
+	}
+
+	@DisplayName("새로운 커뮤니티 글 작성은, 로그인 된 사용자만 가능합니다.")
+	@Test
+	void createNewBoard2() throws Exception {
+		// given
+		List<CommunityCategory> savedCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+
+		CommunityCategory savedCommunityCategory = savedCommunityCategoryList.getFirst();
+		Long communityCategoryId = savedCommunityCategory.getId();
+
+		CommunityRequest.CreateBoard createBoard =
+			new CommunityRequest.CreateBoard(communityCategoryId, "title", "content");
+
+		// when
+		ResultActions perform = mockMvc.perform(post("/api/v1/community/board")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(createBoard)));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isUnauthorized());
+	}
+
+	@WithCustomMember
+	@DisplayName("커뮤니티 글 목록을 조회합니다.")
+	@Test
+	void getBoardList1() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/board"));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_SEARCH_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_SEARCH_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.content").isArray());
+	}
+
+	@DisplayName("커뮤니티 글 목록을 조회합니다. 비회원도 조회 가능합니다.")
+	@Test
+	void getBoardList2() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/board"));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_SEARCH_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_SEARCH_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.content").isArray());
+	}
+
+	@WithCustomMember
+	@DisplayName("커뮤니티 글 내용을 상세 조회합니다.")
+	@Test
+	void getBoardDetail1() throws Exception {
+		// given
+		List<Member> saveMemberList = memberDataFactory.createAndSaveMember(1);
+		List<CommunityCategory> saveCommunityCategoryList = communityDataFactory.createAndSaveCommunityCategory();
+		Community saveCommunity = communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList,
+				1)
+			.getFirst();
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/board/{id}", saveCommunity.getId()));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.content").isNotEmpty());
+	}
+
+	@DisplayName("커뮤니티 글 내용을 상세 조회합니다. 비회원도 조회가 가능합니다.")
+	@Test
+	void getBoardDetail2() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/board/{id}", 1));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_DETAIL_SEARCH_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.content").isNotEmpty());
+	}
+
+	@WithCustomMember
+	@DisplayName("글 수정을 진행합니다.")
+	@Test
+	void modifyBoard1() throws Exception {
+		// given
+		List<Member> saveMemberList = memberRepository.findAll();
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		Community saveCommunity =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 1).getFirst();
+		CommunityRequest.ModifyBoard modifyBoard = new CommunityRequest.ModifyBoard("title", "content");
+
+		// when
+		ResultActions perform = mockMvc.perform(put("/api/v1/community/board/{id}", saveCommunity.getId())
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(modifyBoard)));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_MODIFY_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_MODIFY_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data").isNotEmpty());
+	}
+
+	@DisplayName("글 수정을 진행합니다. 로그인 된 사용자만 이용할 수 있습니다.")
+	@Test
+	void modifyBoard2() throws Exception {
+		// given
+		CommunityRequest.ModifyBoard modifyBoard = new CommunityRequest.ModifyBoard("title", "content");
+
+		// when
+		ResultActions perform = mockMvc.perform(put("/api/v1/community/board/{id}", 1)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(modifyBoard)));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isUnauthorized());
+	}
+
+	@WithCustomMember
+	@DisplayName("커뮤니티 글 삭제")
+	@Test
+	void deleteBoard1() throws Exception {
+		// given
+		List<Member> saveMemberList = memberRepository.findAll();
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		Community saveCommunity =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 1).getFirst();
+
+		// when
+		ResultActions perform = mockMvc.perform(delete("/api/v1/community/board/{id}", saveCommunity.getId()));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_DELETE_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_DELETE_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@DisplayName("커뮤니티 글 삭제. 로그인 된 사용자만 이용할 수 있습니다.")
+	@Test
+	void deleteBoard2() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(delete("/api/v1/community/board/{id}", 1));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isUnauthorized());
+	}
+}

--- a/src/test/java/ssammudan/cotree/domain/community/controller/CommunityControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/community/controller/CommunityControllerTest.java
@@ -153,9 +153,14 @@ class CommunityControllerTest extends SpringBootTestSupporter {
 	@Test
 	void getBoardDetail2() throws Exception {
 		// given
+		List<Member> saveMemberList = memberDataFactory.createAndSaveMember(1);
+		List<CommunityCategory> saveCommunityCategoryList = communityDataFactory.createAndSaveCommunityCategory();
+		Community saveCommunity = communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList,
+				1)
+			.getFirst();
 
 		// when
-		ResultActions perform = mockMvc.perform(get("/api/v1/community/board/{id}", 1));
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/board/{id}", saveCommunity.getId()));
 
 		// then
 		perform.andDo(print())
@@ -238,6 +243,37 @@ class CommunityControllerTest extends SpringBootTestSupporter {
 
 		// when
 		ResultActions perform = mockMvc.perform(delete("/api/v1/community/board/{id}", 1));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isUnauthorized());
+	}
+
+	@WithCustomMember
+	@DisplayName("내가 좋아요 누른 커뮤니티 글을 조회합니다.")
+	@Test
+	void getLikeBoardList1() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/like"));
+
+		// then
+		perform.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess").value(true))
+			.andExpect(jsonPath("$.message").value(SuccessCode.COMMUNITY_BOARD_LIKE_SEARCH_SUCCESS.getMessage()))
+			.andExpect(jsonPath("$.code").value(SuccessCode.COMMUNITY_BOARD_LIKE_SEARCH_SUCCESS.getCode()))
+			.andExpect(jsonPath("$.data.content").isArray());
+	}
+
+	@DisplayName("내가 좋아요 누른 커뮤니티 글을 조회합니다. 로그인 한 회원만 가능합니다.")
+	@Test
+	void getLikeBoardList2() throws Exception {
+		// given
+
+		// when
+		ResultActions perform = mockMvc.perform(get("/api/v1/community/like"));
 
 		// then
 		perform.andDo(print())

--- a/src/test/java/ssammudan/cotree/domain/community/service/CommunityServiceImplTest.java
+++ b/src/test/java/ssammudan/cotree/domain/community/service/CommunityServiceImplTest.java
@@ -430,6 +430,50 @@ class CommunityServiceImplTest extends SpringBootTestSupporter {
 			.isEqualTo(ErrorCode.COMMUNITY_BOARD_NOTFOUND);
 	}
 
+	@DisplayName("내가 좋아요한 커뮤니티 글을 조회합니다.")
+	@Test
+	void getBoardLikeList1() {
+		// given
+		List<Member> saveMemberList =
+			memberDataFactory.createAndSaveMember(1);
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		List<Community> saveCommunityList =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 10);
+		likeDataFactory.createAndSaveCommunityLike(saveMemberList, saveCommunityList);
+
+		Member saveMember = saveMemberList.getFirst();
+		Pageable pageable = PageRequest.of(0, 16);
+
+		// when
+		PageResponse<CommunityResponse.BoardLikeListDetail> content =
+			communityService.getBoardLikeList(pageable, saveMember.getId());
+
+		// then
+		assertThat(content)
+			.satisfies(data -> {
+				assertThat(data.getPageNo()).isZero();
+				assertThat(data.getPageSize()).isEqualTo(16);
+				assertThat(data.getTotalElements()).isEqualTo(20);
+				assertThat(data.getTotalPages()).isEqualTo(2);
+				assertThat(data.isLast()).isFalse();
+				assertThat(data.isFirst()).isTrue();
+				assertThat(data.isHasNext()).isTrue();
+				assertThat(data.isHasPrevious()).isFalse();
+			});
+
+		assertThat(content.getContent())
+			.hasSize(16);
+		assertThat(content.getContent())
+			.allSatisfy(data -> {
+				assertThat(data.id()).isNotNull();
+				assertThat(data.title()).isNotNull();
+				assertThat(data.author()).isNotNull();
+				assertThat(data.createdAt()).isNotNull();
+				assertThat(data.content()).isNotNull();
+			});
+	}
+
 	private @NotNull String createNewMarkdownContent(final boolean isImageExist) {
 		String content = """
 			# 새글 제목

--- a/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
+++ b/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
@@ -28,6 +28,7 @@ import ssammudan.cotree.infra.sms.SmsService;
 import ssammudan.cotree.integration.factory.CommunityDataFactory;
 import ssammudan.cotree.integration.factory.LikeDataFactory;
 import ssammudan.cotree.integration.factory.MemberDataFactory;
+import ssammudan.cotree.model.common.like.repository.LikeRepository;
 import ssammudan.cotree.model.community.category.repository.CommunityCategoryRepository;
 import ssammudan.cotree.model.community.community.repository.CommunityRepository;
 import ssammudan.cotree.model.education.techbook.techbook.repository.TechBookRepository;
@@ -106,6 +107,8 @@ public abstract class SpringBootTestSupporter {
 	protected PortfolioRepository portfolioRepository;
 	@Autowired
 	protected MemberRepository memberRepository;
+	@Autowired
+	protected LikeRepository likeRepository;
 
 	/**
 	 * service

--- a/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
+++ b/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
@@ -32,6 +32,7 @@ import ssammudan.cotree.model.community.category.repository.CommunityCategoryRep
 import ssammudan.cotree.model.community.community.repository.CommunityRepository;
 import ssammudan.cotree.model.education.techbook.techbook.repository.TechBookRepository;
 import ssammudan.cotree.model.education.techtube.techtube.repository.TechTubeRepository;
+import ssammudan.cotree.model.member.member.repository.MemberRepository;
 import ssammudan.cotree.model.recruitment.career.career.repository.CareerRepository;
 import ssammudan.cotree.model.recruitment.portfolio.portfolio.repository.PortfolioRepository;
 import ssammudan.cotree.model.recruitment.resume.resume.repository.ResumeRepository;
@@ -103,6 +104,8 @@ public abstract class SpringBootTestSupporter {
 	protected CareerRepository careerRepository;
 	@Autowired
 	protected PortfolioRepository portfolioRepository;
+	@Autowired
+	protected MemberRepository memberRepository;
 
 	/**
 	 * service

--- a/src/test/java/ssammudan/cotree/integration/security/WithCustomMember.java
+++ b/src/test/java/ssammudan/cotree/integration/security/WithCustomMember.java
@@ -9,10 +9,10 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 
 /**
  * PackageName : ssammudan.cotree.integration.security
- * FileName    : WithCustomUser
+ * FileName    : WithCustomMember
  * Author      : Baekgwa
  * Date        : 2025-04-11
- * Description : 
+ * Description : 무작위 회원을 한명 생성하여 저장 후, securityContext 에 저장합니다.
  * =====================================================================================================================
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
@@ -20,6 +20,6 @@ import org.springframework.security.test.context.support.WithSecurityContext;
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WithCustomUserSecurityContextFactory.class)
-public @interface WithCustomUser {
+@WithSecurityContext(factory = WithCustomMemberSecurityContextFactory.class)
+public @interface WithCustomMember {
 }

--- a/src/test/java/ssammudan/cotree/integration/security/WithCustomMemberSecurityContextFactory.java
+++ b/src/test/java/ssammudan/cotree/integration/security/WithCustomMemberSecurityContextFactory.java
@@ -11,13 +11,16 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import ssammudan.cotree.domain.member.dto.signup.MemberSignupRequest;
 import ssammudan.cotree.global.config.security.user.CustomUser;
 import ssammudan.cotree.model.member.member.entity.Member;
+import ssammudan.cotree.model.member.member.entity.MemberFactory;
 import ssammudan.cotree.model.member.member.repository.MemberRepository;
+import ssammudan.cotree.model.member.member.type.MemberRole;
 
 /**
  * PackageName : ssammudan.cotree.integration.security
- * FileName    : WithCustomUserSecurityContextFactory
+ * FileName    : WithCustomMemberSecurityContextFactory
  * Author      : Baekgwa
  * Date        : 2025-04-11
  * Description : 
@@ -28,20 +31,25 @@ import ssammudan.cotree.model.member.member.repository.MemberRepository;
  */
 @Component
 @RequiredArgsConstructor
-public class WithCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomUser> {
+public class WithCustomMemberSecurityContextFactory implements WithSecurityContextFactory<WithCustomMember> {
 
 	private final MemberRepository memberRepository;
 
 	@Override
-	public SecurityContext createSecurityContext(WithCustomUser annotation) {
+	public SecurityContext createSecurityContext(WithCustomMember annotation) {
 		SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-		Member findMember = memberRepository.findAll().getFirst();
+		Member newMember = MemberFactory.createSignUpMember(
+			new MemberSignupRequest("mockMember", "!asdf1234", "mock member", "mock member nickname",
+				MemberRole.USER.getRole(), "01099999999")
+		);
 
-		CustomUser customUser = new CustomUser(findMember, null);
+		Member savedMember = memberRepository.save(newMember);
+
+		CustomUser customUser = new CustomUser(savedMember, null);
 
 		Authentication auth = new UsernamePasswordAuthenticationToken(
-			customUser, null, List.of(new SimpleGrantedAuthority(findMember.getRole().getRole()))
+			customUser, null, List.of(new SimpleGrantedAuthority(savedMember.getRole().getRole()))
 		);
 
 		context.setAuthentication(auth);

--- a/src/test/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryImplTest.java
+++ b/src/test/java/ssammudan/cotree/model/common/like/repository/LikeRepositoryImplTest.java
@@ -1,0 +1,79 @@
+package ssammudan.cotree.model.common.like.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import ssammudan.cotree.domain.community.dto.CommunityResponse;
+import ssammudan.cotree.integration.SpringBootTestSupporter;
+import ssammudan.cotree.model.community.category.entity.CommunityCategory;
+import ssammudan.cotree.model.community.community.entity.Community;
+import ssammudan.cotree.model.member.member.entity.Member;
+
+/**
+ * PackageName : ssammudan.cotree.model.common.like.repository
+ * FileName    : LikeRepositoryImplTest
+ * Author      : Baekgwa
+ * Date        : 2025-04-13
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-04-13     Baekgwa               Initial creation
+ */
+@Transactional
+class LikeRepositoryImplTest extends SpringBootTestSupporter {
+
+	@DisplayName("내가 좋아요 누른 커뮤니티 글을 조회 합니다.")
+	@Test
+	void findBoardLikeList1() {
+		// given
+		List<Member> saveMemberList =
+			memberDataFactory.createAndSaveMember(1);
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		List<Community> saveCommunityList =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 10);
+		likeDataFactory.createAndSaveCommunityLike(saveMemberList, saveCommunityList);
+
+		Member saveMember = saveMemberList.getFirst();
+		Pageable pageable = PageRequest.of(0, 16);
+
+		// when
+		Page<CommunityResponse.BoardLikeListDetail> content =
+			likeRepository.findBoardLikeList(pageable, saveMember.getId());
+
+		// then
+		assertThat(content).asInstanceOf(InstanceOfAssertFactories.type(Page.class))
+			.satisfies(page -> {
+				assertThat(page.getTotalElements()).isEqualTo(20L);
+				assertThat(page.getTotalPages()).isEqualTo(2);
+				assertThat(page.getNumber()).isZero();
+				assertThat(page.getSize()).isEqualTo(16);
+				assertThat(page.getNumberOfElements()).isEqualTo(16);
+				assertThat(page.isFirst()).isTrue();
+				assertThat(page.isLast()).isFalse();
+				assertThat(page.hasNext()).isTrue();
+				assertThat(page.hasPrevious()).isFalse();
+			});
+
+		assertThat(content.getContent())
+			.hasSize(16);
+		assertThat(content.getContent())
+			.allSatisfy(data -> {
+				assertThat(data.id()).isNotNull();
+				assertThat(data.title()).isNotNull();
+				assertThat(data.author()).isNotNull();
+				assertThat(data.createdAt()).isNotNull();
+				assertThat(data.content()).isNotNull();
+			});
+	}
+}

--- a/src/test/java/ssammudan/cotree/model/community/category/repository/CommunityRepositoryTest.java
+++ b/src/test/java/ssammudan/cotree/model/community/category/repository/CommunityRepositoryTest.java
@@ -378,4 +378,92 @@ class CommunityRepositoryTest extends SpringBootTestSupporter {
 		assertThat(content.getContent())
 			.isEmpty();
 	}
+
+	@DisplayName("글 전체 내용을 페이지네이션 조회 한다. 조건 : [5개씩, 0번페이지, 1번 카테고리, 댓글순, 키워드 : TEST, 비 로그인 상태]")
+	@Test
+	void findBoardList5() {
+		// given
+		// 회원 2명
+		List<Member> saveMemberList =
+			memberDataFactory.createAndSaveMember(2);
+		// 커뮤니티 카테고리 2개
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		// 커뮤니티 글 = 회원수 * 카테고리 수 * count = 2 * 2 * 2 = 8
+		List<Community> saveCommuintyList =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 2);
+		// 댓글 수 : member * community * count = 2 * 8 * 2 = 32
+		// 대댓글 수 : 댓글 수 * count = 32 * 2 = 64
+		commentDataFactory.createAndSaveCommunityComment(saveMemberList, saveCommuintyList, 2);
+		likeDataFactory.createAndSaveCommunityLike(saveMemberList, saveCommuintyList);
+
+		Pageable pageable = PageRequest.of(0, 5);
+		SearchBoardSort sort = SearchBoardSort.COMMENT;
+		SearchBoardCategory category = SearchBoardCategory.CODE_REVIEW;
+
+		// when
+		Page<CommunityResponse.BoardListDetail> content =
+			communityRepository.findBoardList(pageable, sort, category, "TEST", null);
+
+		// then
+		assertThat(content).asInstanceOf(InstanceOfAssertFactories.type(Page.class))
+			.satisfies(page -> {
+				assertThat(page.getTotalElements()).isZero();
+				assertThat(page.getTotalPages()).isZero();
+				assertThat(page.getNumber()).isZero();
+				assertThat(page.getSize()).isEqualTo(5);
+				assertThat(page.getNumberOfElements()).isZero();
+				assertThat(page.isFirst()).isTrue();
+				assertThat(page.isLast()).isTrue();
+				assertThat(page.hasNext()).isFalse();
+				assertThat(page.hasPrevious()).isFalse();
+			});
+
+		assertThat(content.getContent())
+			.isEmpty();
+	}
+
+	@DisplayName("글 전체 내용을 페이지네이션 조회 한다. 조건 : [5개씩, 0번페이지, 1번 카테고리, 좋아요순, 키워드 : TEST, 비 로그인 상태]")
+	@Test
+	void findBoardList6() {
+		// given
+		// 회원 2명
+		List<Member> saveMemberList =
+			memberDataFactory.createAndSaveMember(2);
+		// 커뮤니티 카테고리 2개
+		List<CommunityCategory> saveCommunityCategoryList =
+			communityDataFactory.createAndSaveCommunityCategory();
+		// 커뮤니티 글 = 회원수 * 카테고리 수 * count = 2 * 2 * 2 = 8
+		List<Community> saveCommuintyList =
+			communityDataFactory.createAndSaveCommunity(saveMemberList, saveCommunityCategoryList, 2);
+		// 댓글 수 : member * community * count = 2 * 8 * 2 = 32
+		// 대댓글 수 : 댓글 수 * count = 32 * 2 = 64
+		commentDataFactory.createAndSaveCommunityComment(saveMemberList, saveCommuintyList, 2);
+		likeDataFactory.createAndSaveCommunityLike(saveMemberList, saveCommuintyList);
+
+		Pageable pageable = PageRequest.of(0, 5);
+		SearchBoardSort sort = SearchBoardSort.LIKE;
+		SearchBoardCategory category = SearchBoardCategory.CODE_REVIEW;
+
+		// when
+		Page<CommunityResponse.BoardListDetail> content =
+			communityRepository.findBoardList(pageable, sort, category, "TEST", null);
+
+		// then
+		assertThat(content).asInstanceOf(InstanceOfAssertFactories.type(Page.class))
+			.satisfies(page -> {
+				assertThat(page.getTotalElements()).isZero();
+				assertThat(page.getTotalPages()).isZero();
+				assertThat(page.getNumber()).isZero();
+				assertThat(page.getSize()).isEqualTo(5);
+				assertThat(page.getNumberOfElements()).isZero();
+				assertThat(page.isFirst()).isTrue();
+				assertThat(page.isLast()).isTrue();
+				assertThat(page.hasNext()).isFalse();
+				assertThat(page.hasPrevious()).isFalse();
+			});
+
+		assertThat(content.getContent())
+			.isEmpty();
+	}
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#217 
  <br/>

## 🔎 작업 내용
- Community Controller 테스트를 추가하였습니다.
- 기타 누락된, 내가 좋아요 누른 Community 글 리스트 조회와 관련된 단위/통합 테스트 추가하였습니다.
- jacoco 관련 설정을 추가하였습니다.
  - 현재는 설정만 추가하고, 커버리지에 따른 build 성공/실패를 false 로 꺼두었습니다.
![image](https://github.com/user-attachments/assets/05260359-d578-4bcc-b1b8-e17698ef1989)
![image](https://github.com/user-attachments/assets/6c453afc-801d-4542-9300-ff94a54fcdac)

- 테스트 한 레이어는, `Controller`, `Service`, `Repository`, `RequestDto` 입니다.
Controller : 요청이 접수되면 올바르게 response 하는지.
Service : service 로직이 재대로 실행 되는지
Repository : db 에 조회를 잘 하는지
RequestDto : 입력된 Dto 의 값이 설정된 유효성을 통과하는지
- 이런 목표로 작성되었습니다.


  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- controller 테스트 시, Spring Security 가 있는 상태에서 진행하기 위해, `WithCustomMember` 라는 어노테이션을 만들었습니다.
- 내부적으로, `WithCustomMemberSecurityContextFactory` 에서는 신규 Member를 만들어 DB에 저장, Security Context 에 추가 하도록 구성하였습니다.
- 해당 annotation 을 통한 member 생성은 class 의 @transaction 범위에 들어가지 않아, @AfterEach 를 통해, 저장된 member를 삭제하도록 tearDown() 메서드를 구현하였습니다.
- 결과적으로는, controller 에서 service 를 목킹하지 않고, 영속성 까지 내려가는 통합테스트를 진행하도록 하였습니다.
- 해당 과정에 대한 전반적인 리뷰를 요청드립니다. (올바른지..?)
---
- 추가적으로, 모든 과정은 `@SpringBootTest` 를 통해 진행하였고, 별도의 `@DataJpaTest` 는 사용하지 않았습니다.
- 이유는, `@DataJpaTest` 는 최소한의 의존성을 로드하여 테스트를 가볍게 할 수 있어, spring context 생성을 빠르게 진행할 수 있다는 장점이 있는데, `SpringBootTestSupporter` class 를 통해, 진행한 모든 테스트를 하나의 spring context 에서 진행하였기 때문에 필요없다고 느꼈습니다.
- 해당 방법에 대한 의견또한 궁금합니다.

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>