### PR TITLE
[FEAT]: CustomUserDetailsService.loadUserByRefreshToken 구현

### DIFF
--- a/src/main/java/ssammudan/cotree/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ssammudan/cotree/global/config/security/filter/JwtAuthenticationFilter.java
@@ -70,8 +70,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				filterChain.doFilter(request, response);
 				return;
 			}
-			String memberId = refreshTokenService.getClaimsFromToken(refreshToken).get("mid", String.class);
-			user = customUserDetailsService.loadUserById(memberId);
+			user = customUserDetailsService.loadUserByRefreshToken(refreshToken);
 
 			if (user == null) {
 				filterChain.doFilter(request, response);

--- a/src/main/java/ssammudan/cotree/global/config/security/user/CustomUserDetailsService.java
+++ b/src/main/java/ssammudan/cotree/global/config/security/user/CustomUserDetailsService.java
@@ -57,4 +57,16 @@ public class CustomUserDetailsService implements UserDetailsService {
 		}
 	}
 
+	public CustomUser loadUserByRefreshToken(String refreshToken) {
+		try {
+			Claims claimsFromToken = refreshTokenService.getClaimsFromToken(refreshToken);
+			String id = claimsFromToken.get("mid", String.class);
+			Member member = memberRepository.findById(id)
+				.orElseThrow(() -> new GlobalException(ErrorCode.MEMBER_NOT_FOUND));
+			return new CustomUser(member, null);
+		} catch (Exception e) { // Jwt는 굳이 예외처리하지 않음. 이 후 필터로 전달하기 위해
+			return null;
+		}
+	}
+
 }


### PR DESCRIPTION
- refreshToken을 사용한 인증정보 확인 메서드 구현

<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#230 
  <br/>

## 🔎 작업 내용
- 인증정보가 없다면 예외를 던져서 프로그램이 중단되지 않고 null을 반환하여 다음 필터로 넘어갈 수 있도록 로직을 수정하였습니다.
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>