### PR TITLE
[TEST] ResumeDataFactory 클래스명을 ResumeProjectTestDataFactory로 변경

### DIFF
--- a/src/test/java/ssammudan/cotree/domain/resume/controller/ResumeControllerTest.java
+++ b/src/test/java/ssammudan/cotree/domain/resume/controller/ResumeControllerTest.java
@@ -46,7 +46,7 @@ class ResumeControllerTest extends SpringBootTestSupporter {
 
 	@BeforeEach
 	void setUp() {
-		member = resumeDataFactory.setData();
+		member = resumeProjectTestDataFactory.setData();
 		customUser = customUserDetailsService.loadUserByUsername(member.getUsername());
 	}
 
@@ -117,7 +117,6 @@ class ResumeControllerTest extends SpringBootTestSupporter {
 		ResumeCreateRequest request = createRegisterRequest();
 		resumeService.register(request, member.getId(), null);
 		resumeService.register(request, member.getId(), null);
-
 
 		ResultActions resultActions = mockMvc
 			.perform(get("/api/v1/recruitment/resume")

--- a/src/test/java/ssammudan/cotree/domain/resume/service/ResumeServiceImplTest.java
+++ b/src/test/java/ssammudan/cotree/domain/resume/service/ResumeServiceImplTest.java
@@ -44,7 +44,7 @@ class ResumeServiceImplTest extends SpringBootTestSupporter {
 
 	@BeforeEach
 	void setUp() {
-		memberId = resumeDataFactory.setData().getId();
+		memberId = resumeProjectTestDataFactory.setData().getId();
 	}
 
 	@Test

--- a/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
+++ b/src/test/java/ssammudan/cotree/integration/SpringBootTestSupporter.java
@@ -16,18 +16,18 @@ import ssammudan.cotree.domain.community.service.CommunityService;
 import ssammudan.cotree.domain.education.techbook.service.TechBookService;
 import ssammudan.cotree.domain.education.techtube.service.TechTubeService;
 import ssammudan.cotree.domain.email.service.EmailService;
-import ssammudan.cotree.global.config.security.user.CustomUserDetailsService;
-import ssammudan.cotree.integration.factory.ResumeDataFactory;
 import ssammudan.cotree.domain.resume.service.ResumeService;
 import ssammudan.cotree.domain.review.service.TechEducationReviewService;
+import ssammudan.cotree.global.config.security.user.CustomUserDetailsService;
 import ssammudan.cotree.infra.s3.S3Uploader;
+import ssammudan.cotree.infra.sms.SmsService;
 import ssammudan.cotree.infra.viewcount.persistence.ViewCountScheduler;
 import ssammudan.cotree.infra.viewcount.persistence.ViewCountStore;
 import ssammudan.cotree.integration.factory.CommentDataFactory;
-import ssammudan.cotree.infra.sms.SmsService;
 import ssammudan.cotree.integration.factory.CommunityDataFactory;
 import ssammudan.cotree.integration.factory.LikeDataFactory;
 import ssammudan.cotree.integration.factory.MemberDataFactory;
+import ssammudan.cotree.integration.factory.shared.ResumeProjectTestDataFactory;
 import ssammudan.cotree.model.common.like.repository.LikeRepository;
 import ssammudan.cotree.model.community.category.repository.CommunityCategoryRepository;
 import ssammudan.cotree.model.community.community.repository.CommunityRepository;
@@ -74,7 +74,7 @@ public abstract class SpringBootTestSupporter {
 	@Autowired
 	protected CommentDataFactory commentDataFactory;
 	@Autowired
-	protected ResumeDataFactory resumeDataFactory;
+	protected ResumeProjectTestDataFactory resumeProjectTestDataFactory;
 
 	/**
 	 * Common

--- a/src/test/java/ssammudan/cotree/integration/factory/shared/ResumeProjectTestDataFactory.java
+++ b/src/test/java/ssammudan/cotree/integration/factory/shared/ResumeProjectTestDataFactory.java
@@ -1,4 +1,4 @@
-package ssammudan.cotree.integration.factory;
+package ssammudan.cotree.integration.factory.shared;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,9 +29,10 @@ import ssammudan.cotree.model.member.member.type.MemberStatus;
  * DATE          AUTHOR               NOTE
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025. 3. 31.     kwak               Initial creation
+ * 2025. 4. 17.     sangxxjin          Resume, Project 공통 클래스로 변경
  */
 @Component
-public class ResumeDataFactory {
+public class ResumeProjectTestDataFactory {
 	@Autowired
 	private MemberRepository memberRepository;
 


### PR DESCRIPTION
 - 해당 데이터가 Resume, Project에서 공통적으로 사용하기 떄문에 공통 클래스로 변경

<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#220
  <br/>

## 🔎 작업 내용
- ResumeDataFactory 클래스명을 ResumeProjectTestDataFactory로 변경
  - Project에서 필요한 데이터가 똑같기 때문에 ResumeDataFactory의 클래스 명을 변경하고 공통적으로 사용

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
 - 적절한 클래스명을 고민하다가 ResumeProjectTestDataFactory로 정했습니다.
   - 적절한 이름이 있다면 조언 부탁드립니다.
  <br/>