### PR TITLE
[REFACTOR] 채용 도메인 이력서 조회 성능 개선

### DIFF
--- a/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDslImpl.java
+++ b/src/main/java/ssammudan/cotree/model/recruitment/resume/resume/repository/ResumeRepositoryQueryDslImpl.java
@@ -53,7 +53,7 @@ public class ResumeRepositoryQueryDslImpl implements ResumeRepositoryQueryDsl {
 
 		// 기본 정보 조회
 		List<ResumeBasicInfoDto> resumeBasicInfos = jpaQueryFactory
-			.select(
+			.selectDistinct(
 				Projections.constructor(
 					ResumeBasicInfoDto.class,
 					resume.id,
@@ -70,7 +70,6 @@ public class ResumeRepositoryQueryDslImpl implements ResumeRepositoryQueryDsl {
 			.join(resume.resumeTechStacks, resumeTechStack)
 			.join(resumeTechStack.techStack, techStack)
 			.where(whereCondition)
-			.groupBy(resume.id)
 			.orderBy(getOrderSpecifier(sort))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/src/main/resources/db/migration/V3.2__add_index_recruitment_resume.sql
+++ b/src/main/resources/db/migration/V3.2__add_index_recruitment_resume.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_resume_view_count ON resume (view_count DESC);
+CREATE INDEX idx_resume_created_at ON resume (created_at DESC);


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#265
  <br/>

## 🔎 작업 내용

P95 서버 기준 500ms 이상 나오는 API 애 대해 집중적으로 성능 최적화
[채용] 이력서 리스트 조회순, 직무 조회
[채용] 이력서 리스트 조회순 조회
[채용] 이력서 초기 리스트 조회

- group by 제외 하고 distinct 적용 
- order by 절에 사용되는 칼럼에 인덱스 적용

로컬 기준 220 으로 형성되던 이력서 초기 리스트 조회와 이력서 리스트 조회순 조회가 
95% Line 기준 120~130 으로 감소 (약 40%~50% 감소)
Explain 에서도 `Using filesort` 제거


  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>